### PR TITLE
Implement 3D Primo rendering experiment

### DIFF
--- a/backend/src/main/java/com/primos/model/Primo3D.java
+++ b/backend/src/main/java/com/primos/model/Primo3D.java
@@ -1,0 +1,44 @@
+package com.primos.model;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+
+@MongoEntity(collection = "primos3D")
+public class Primo3D extends PanacheMongoEntity {
+    private String tokenAddress;
+    private String name;
+    private String image;
+    private String stlUrl;
+
+    public String getTokenAddress() {
+        return tokenAddress;
+    }
+
+    public void setTokenAddress(String tokenAddress) {
+        this.tokenAddress = tokenAddress;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public String getStlUrl() {
+        return stlUrl;
+    }
+
+    public void setStlUrl(String stlUrl) {
+        this.stlUrl = stlUrl;
+    }
+}

--- a/backend/src/main/java/com/primos/resource/Primo3DResource.java
+++ b/backend/src/main/java/com/primos/resource/Primo3DResource.java
@@ -1,0 +1,33 @@
+package com.primos.resource;
+
+import com.primos.model.Primo3D;
+import com.primos.service.Primo3DService;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api/primo3d")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class Primo3DResource {
+
+    @Inject
+    Primo3DService service;
+
+    @POST
+    public Primo3D renderPrimo(Primo3D req) {
+        return service.create(req);
+    }
+
+    @GET
+    @Path("/{token}")
+    public Primo3D get(@PathParam("token") String token) {
+        return Primo3D.find("tokenAddress", token).firstResult();
+    }
+}

--- a/backend/src/main/java/com/primos/service/Primo3DService.java
+++ b/backend/src/main/java/com/primos/service/Primo3DService.java
@@ -1,0 +1,17 @@
+package com.primos.service;
+
+import com.primos.model.Primo3D;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Primo3DService {
+    public Primo3D create(Primo3D primo) {
+        Primo3D existing = Primo3D.find("tokenAddress", primo.getTokenAddress()).firstResult();
+        if (existing != null) {
+            return existing;
+        }
+        primo.persist();
+        return primo;
+    }
+}

--- a/backend/src/test/java/com/primos/resource/Primo3DResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/Primo3DResourceTest.java
@@ -1,0 +1,22 @@
+package com.primos.resource;
+
+import com.primos.model.Primo3D;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Primo3DResourceTest {
+    @Test
+    public void testCreateAndFetch() {
+        Primo3DResource res = new Primo3DResource();
+        Primo3D req = new Primo3D();
+        req.setTokenAddress("tok1");
+        req.setName("Primo #1");
+        req.setImage("img");
+        req.setStlUrl("url");
+        Primo3D created = res.renderPrimo(req);
+        assertNotNull(created);
+        Primo3D fetched = res.get("tok1");
+        assertEquals("tok1", fetched.getTokenAddress());
+        assertEquals("Primo #1", fetched.getName());
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@solana/wallet-adapter-react-ui": "^0.9.38",
     "@solana/wallet-adapter-wallets": "^0.19.36",
     "@solana/web3.js": "^1.98.2",
+    "@splinetool/react-spline": "^1.3.2",
     "assert": "^2.1.0",
     "axios": "^1.9.0",
     "buffer": "^6.0.3",

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -146,16 +146,18 @@
   "not_redeemed": "Not Redeemed",
   "checking_access": "Checking access...",
   "not_holder_message": "You’re not a Primo NFT holder! Lerolero",
-  "invalid_code_format": "Invalid code format. Must be BETA-XXXXXXXX"
-  ,"active_codes": "Active Codes"
-  ,"redeemed_codes": "Redeemed Codes"
-  ,"stats": "Stats"
-  ,"total_wallets": "Total Wallets"
-  ,"total_points": "Total Points"
-  ,"primo_holders": "Primo Holders"
-  ,"total_beta": "Total Beta Codes"
-  ,"total_beta_redeemed": "Redeemed Beta Codes"
-  ,"nfts_held": "Primos Held"
-  ,"wallets_with_nfts": "Wallets with Primos"
-  ,"db_market_cap": "DB Market Cap"
+  "invalid_code_format": "Invalid code format. Must be BETA-XXXXXXXX",
+  "active_codes": "Active Codes",
+  "redeemed_codes": "Redeemed Codes",
+  "stats": "Stats",
+  "total_wallets": "Total Wallets",
+  "total_points": "Total Points",
+  "primo_holders": "Primo Holders",
+  "total_beta": "Total Beta Codes",
+  "total_beta_redeemed": "Redeemed Beta Codes",
+  "nfts_held": "Primos Held",
+  "wallets_with_nfts": "Wallets with Primos",
+  "db_market_cap": "DB Market Cap",
+  "experiment1_select": "Select one of your Primo NFTs to render a 3D model.",
+  "experiment1_rendering": "Rendering..."
 }

--- a/frontend/src/pages/Experiment1.css
+++ b/frontend/src/pages/Experiment1.css
@@ -10,3 +10,21 @@
   border-radius: 0.75rem;
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
 }
+.nft-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+.nft {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+.nft.selected {
+  border-color: #1976d2;
+}

--- a/frontend/src/pages/__tests__/Experiment1.test.tsx
+++ b/frontend/src/pages/__tests__/Experiment1.test.tsx
@@ -5,8 +5,16 @@ import { I18nextProvider } from 'react-i18next';
 import i18n from '../../i18n';
 import Experiment1 from '../Experiment1';
 
+jest.mock('../utils/helius', () => ({
+  fetchCollectionNFTsForOwner: jest.fn(() => Promise.resolve([]))
+}));
+
+jest.mock('../utils/api', () => ({
+  post: jest.fn(() => Promise.resolve({ data: { stlUrl: 'url', tokenAddress: 'x' } }))
+}));
+
 describe('Experiment1 page', () => {
-  test('renders upload prompt', () => {
+  test('renders render button disabled', async () => {
     render(
       <MemoryRouter>
         <I18nextProvider i18n={i18n}>


### PR DESCRIPTION
## Summary
- allow selecting NFTs to render 3D models via new Experiment #1 page
- persist rendered models in new backend collection `primos3D`
- introduce `Primo3D` entity with REST resource and service
- update translation strings and styling
- add minimal unit tests

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm test -- -w 1` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab8564b20832ab0d9e82cb30f08bb