### PR TITLE
Remove unused @splinetool/react-spline dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "@solana/wallet-adapter-react-ui": "^0.9.38",
     "@solana/wallet-adapter-wallets": "^0.19.36",
     "@solana/web3.js": "^1.98.2",
-    "@splinetool/react-spline": "^1.3.2",
     "assert": "^2.1.0",
     "axios": "^1.9.0",
     "buffer": "^6.0.3",

--- a/frontend/src/pages/Experiment1.tsx
+++ b/frontend/src/pages/Experiment1.tsx
@@ -6,7 +6,6 @@ import { useWallet } from '@solana/wallet-adapter-react';
 import { useTranslation } from 'react-i18next';
 import { fetchCollectionNFTsForOwner, HeliusNFT } from '../utils/helius';
 import api from '../utils/api';
-import Spline from '@splinetool/react-spline';
 import './Experiment1.css';
 
 const PRIMO_COLLECTION = process.env.REACT_APP_PRIMOS_COLLECTION!;
@@ -85,7 +84,11 @@ const Experiment1: React.FC = () => {
         </>
       ) : (
         <Box sx={{ mt: 3 }}>
-          <Spline scene={rendered.stlUrl} className="experiment-iframe" />
+          <iframe
+            src={rendered.stlUrl}
+            className="experiment-iframe"
+            title="Primo 3D model"
+          />
         </Box>
       )}
     </Box>


### PR DESCRIPTION
## Summary
- remove `@splinetool/react-spline` from dependencies
- update Experiment1 page to embed the rendered 3D model via iframe

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*
- `mvn test -q` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abd635b00832abf53613dc9889c76