### PR TITLE
Add Meshy API integration and notifications

### DIFF
--- a/backend/src/main/java/com/primos/model/Notification.java
+++ b/backend/src/main/java/com/primos/model/Notification.java
@@ -1,0 +1,24 @@
+package com.primos.model;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+
+@MongoEntity(collection = "notifications")
+public class Notification extends PanacheMongoEntity {
+    private String publicKey;
+    private String message;
+    private boolean read;
+    private long createdAt = System.currentTimeMillis();
+
+    public String getPublicKey() { return publicKey; }
+    public void setPublicKey(String publicKey) { this.publicKey = publicKey; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public boolean isRead() { return read; }
+    public void setRead(boolean read) { this.read = read; }
+
+    public long getCreatedAt() { return createdAt; }
+    public void setCreatedAt(long createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/com/primos/model/Primo3D.java
+++ b/backend/src/main/java/com/primos/model/Primo3D.java
@@ -9,6 +9,8 @@ public class Primo3D extends PanacheMongoEntity {
     private String name;
     private String image;
     private String stlUrl;
+    private String jobId;
+    private String status;
 
     public String getTokenAddress() {
         return tokenAddress;
@@ -40,5 +42,21 @@ public class Primo3D extends PanacheMongoEntity {
 
     public void setStlUrl(String stlUrl) {
         this.stlUrl = stlUrl;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
     }
 }

--- a/backend/src/main/java/com/primos/resource/NotificationResource.java
+++ b/backend/src/main/java/com/primos/resource/NotificationResource.java
@@ -1,0 +1,28 @@
+package com.primos.resource;
+
+import com.primos.model.Notification;
+import com.primos.service.NotificationService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+
+@Path("/api/notifications")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class NotificationResource {
+
+    @Inject
+    NotificationService service;
+
+    @GET
+    public List<Notification> get(@HeaderParam("X-Public-Key") String publicKey) {
+        return service.forUser(publicKey);
+    }
+
+    @PUT
+    @Path("/{id}/read")
+    public Notification markRead(@PathParam("id") Long id) {
+        return service.markRead(id);
+    }
+}

--- a/backend/src/main/java/com/primos/resource/Primo3DResource.java
+++ b/backend/src/main/java/com/primos/resource/Primo3DResource.java
@@ -21,8 +21,8 @@ public class Primo3DResource {
     Primo3DService service;
 
     @POST
-    public Primo3D renderPrimo(Primo3D req) {
-        return service.create(req);
+    public Primo3D renderPrimo(@HeaderParam("X-Public-Key") String publicKey, Primo3D req) {
+        return service.create(publicKey, req);
     }
 
     @GET

--- a/backend/src/main/java/com/primos/service/MeshyService.java
+++ b/backend/src/main/java/com/primos/service/MeshyService.java
@@ -1,0 +1,61 @@
+package com.primos.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import jakarta.json.JsonReader;
+
+@ApplicationScoped
+public class MeshyService {
+    private static final String API_BASE = System.getenv().getOrDefault("MESHY_API_BASE", "https://api.meshy.ai");
+    private static final String API_KEY = System.getenv().getOrDefault("MESHY_API_KEY", "");
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    public String startRender(String imageUrl) {
+        try {
+            String payload = Json.createObjectBuilder().add("image", imageUrl).build().toString();
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(URI.create(API_BASE + "/v1/one_click/2dto3d"))
+                    .header("Authorization", "Bearer " + API_KEY)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payload))
+                    .build();
+            HttpResponse<String> res = client.send(req, HttpResponse.BodyHandlers.ofString());
+            if (res.statusCode() == 200) {
+                try (JsonReader reader = Json.createReader(new StringReader(res.body()))) {
+                    JsonObject obj = reader.readObject();
+                    return obj.getString("job_id", null);
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    public RenderStatus checkStatus(String jobId) {
+        try {
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(URI.create(API_BASE + "/v1/jobs/" + jobId))
+                    .header("Authorization", "Bearer " + API_KEY)
+                    .build();
+            HttpResponse<String> res = client.send(req, HttpResponse.BodyHandlers.ofString());
+            if (res.statusCode() == 200) {
+                try (JsonReader reader = Json.createReader(new StringReader(res.body()))) {
+                    JsonObject obj = reader.readObject();
+                    String status = obj.getString("status", "");
+                    String url = obj.getString("output_url", null);
+                    return new RenderStatus(status, url);
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    public record RenderStatus(String status, String url) {}
+}

--- a/backend/src/main/java/com/primos/service/NotificationService.java
+++ b/backend/src/main/java/com/primos/service/NotificationService.java
@@ -1,0 +1,29 @@
+package com.primos.service;
+
+import com.primos.model.Notification;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+@ApplicationScoped
+public class NotificationService {
+    public void add(String publicKey, String message) {
+        Notification n = new Notification();
+        n.setPublicKey(publicKey);
+        n.setMessage(message);
+        n.setRead(false);
+        n.persist();
+    }
+
+    public List<Notification> forUser(String publicKey) {
+        return Notification.list("publicKey = ?1 order by createdAt desc", publicKey);
+    }
+
+    public Notification markRead(Long id) {
+        Notification n = Notification.findById(id);
+        if (n != null) {
+            n.setRead(true);
+            n.persistOrUpdate();
+        }
+        return n;
+    }
+}

--- a/backend/src/main/java/com/primos/service/Primo3DService.java
+++ b/backend/src/main/java/com/primos/service/Primo3DService.java
@@ -1,17 +1,42 @@
 package com.primos.service;
 
 import com.primos.model.Primo3D;
-
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class Primo3DService {
-    public Primo3D create(Primo3D primo) {
+
+    @Inject
+    MeshyService meshy;
+
+    @Inject
+    NotificationService notifications;
+
+    public Primo3D create(String publicKey, Primo3D primo) {
         Primo3D existing = Primo3D.find("tokenAddress", primo.getTokenAddress()).firstResult();
         if (existing != null) {
             return existing;
         }
+        String job = meshy.startRender(primo.getImage());
+        primo.setJobId(job);
+        primo.setStatus(job == null ? "ERROR" : "IN_PROGRESS");
         primo.persist();
+        if (publicKey != null) {
+            notifications.add(publicKey, "3D rendering started for " + primo.getName());
+        }
         return primo;
+    }
+
+    public void updateStatus(Primo3D primo) {
+        if (primo.getJobId() == null) return;
+        MeshyService.RenderStatus status = meshy.checkStatus(primo.getJobId());
+        if (status != null && !status.status().equals(primo.getStatus())) {
+            primo.setStatus(status.status());
+            if (status.url() != null) {
+                primo.setStlUrl(status.url());
+            }
+            primo.persistOrUpdate();
+        }
     }
 }

--- a/backend/src/main/java/com/primos/service/Primo3DStatusJob.java
+++ b/backend/src/main/java/com/primos/service/Primo3DStatusJob.java
@@ -1,0 +1,24 @@
+package com.primos.service;
+
+import com.primos.model.Primo3D;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import io.quarkus.scheduler.Scheduled;
+import java.util.List;
+
+@ApplicationScoped
+public class Primo3DStatusJob {
+    @Inject Primo3DService primoService;
+    @Inject NotificationService notifications;
+
+    @Scheduled(every = "60s")
+    void poll() {
+        List<Primo3D> jobs = Primo3D.list("status", "IN_PROGRESS");
+        for (Primo3D p : jobs) {
+            primoService.updateStatus(p);
+            if ("COMPLETED".equalsIgnoreCase(p.getStatus()) && p.getStlUrl() != null) {
+                notifications.add(p.getTokenAddress(), "3D render completed for " + p.getName());
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/primos/resource/Primo3DResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/Primo3DResourceTest.java
@@ -12,8 +12,7 @@ public class Primo3DResourceTest {
         req.setTokenAddress("tok1");
         req.setName("Primo #1");
         req.setImage("img");
-        req.setStlUrl("url");
-        Primo3D created = res.renderPrimo(req);
+        Primo3D created = res.renderPrimo("user", req);
         assertNotNull(created);
         Primo3D fetched = res.get("tok1");
         assertEquals("tok1", fetched.getTokenAddress());

--- a/backend/src/test/java/com/primos/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/primos/service/NotificationServiceTest.java
@@ -1,0 +1,23 @@
+package com.primos.service;
+
+import com.primos.model.Notification;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+public class NotificationServiceTest {
+    @Test
+    public void testAddAndFetch() {
+        NotificationService svc = new NotificationService();
+        svc.add("user", "hello");
+        List<Notification> list = svc.forUser("user");
+        assertEquals(1, list.size());
+        Notification n = list.get(0);
+        assertEquals("hello", n.getMessage());
+        assertFalse(n.isRead());
+        svc.markRead(n.id);
+        Notification updated = Notification.findById(n.id);
+        assertTrue(updated.isRead());
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,8 @@ import api from './utils/api';
 import logo from './images/primosheadlogo.png';
 import NFTGallery from './pages/NFTGallery';
 import WalletLogin from './components/WalletLogin';
+import Badge from '@mui/material/Badge';
+import NotificationsIcon from '@mui/icons-material/Notifications';
 import UserProfile from './pages/UserProfile';
 import SidebarNav from './components/SidebarNav';
 import PrimosMarketGallery from './pages/PrimosMarketGallery';
@@ -93,11 +95,13 @@ const Header: React.FC = () => {
   const isProfilePage = location.pathname === '/profile';
 
   const [pfpImage, setPfpImage] = useState<string | null>(null);
+  const [notificationCount, setNotificationCount] = useState(0);
 
   useEffect(() => {
     const fetchPfp = async () => {
       if (!publicKey) {
         setPfpImage(null);
+        setNotificationCount(0);
         return;
       }
       try {
@@ -116,6 +120,17 @@ const Header: React.FC = () => {
       }
     };
     fetchPfp();
+    if (publicKey) {
+      api
+        .get('/api/notifications', {
+          headers: { 'X-Public-Key': publicKey.toBase58() },
+        })
+        .then((res) => {
+          const unread = res.data.filter((n: any) => !n.read).length;
+          setNotificationCount(unread);
+        })
+        .catch(() => setNotificationCount(0));
+    }
   }, [publicKey]);
 
   const renderProfileButtonContent = () => {
@@ -169,6 +184,17 @@ const Header: React.FC = () => {
             >
               {renderProfileButtonContent()}
             </Button>
+          )}
+          {publicKey && (
+            <Badge
+              color="error"
+              variant="dot"
+              invisible={notificationCount === 0}
+              sx={{ cursor: 'pointer' }}
+              onClick={() => navigate('/profile#notifications')}
+            >
+              <NotificationsIcon />
+            </Badge>
           )}
           <WalletLogin />
         </Box>

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -159,5 +159,14 @@
   "wallets_with_nfts": "Wallets with Primos",
   "db_market_cap": "DB Market Cap",
   "experiment1_select": "Select one of your Primo NFTs to render a 3D model.",
-  "experiment1_rendering": "Rendering..."
+  "experiment1_rendering": "Rendering...",
+  "render_started": "3D rendering started",
+  "render_complete": "3D rendering complete",
+  "notifications": "Notifications",
+  "no_notifications": "No notifications",
+  "render_confirm": "Are you sure you want to render this NFT in 3D?",
+  "render_thanks": "Rendering started, thank you! Please wait for completion.",
+  "render_status_not_started": "3D rendering not started",
+  "render_status_in_progress": "3D rendering in progress",
+  "render_status_done": "3D rendered"
 }

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -146,16 +146,25 @@
   "beta_dialog_message": "¡Eres poseedor de un Primo NFT! Ingresa tu código beta para completar el acceso.",
   "not_holder_message": "¡No eres poseedor de un Primo NFT! Lerolero",
   "welcome_message": "¡Bienvenido a Primos Marketplace!",
-  "invalid_code_format": "El formato del código es inválido. Debe ser BETA-XXXXXXXX"
-  ,"active_codes": "Códigos Activos"
-  ,"redeemed_codes": "Códigos Canjeados"
-  ,"stats": "Estadísticas"
-  ,"total_wallets": "Billeteras Únicas"
-  ,"total_points": "Puntos Totales"
-  ,"primo_holders": "Primo Holders"
-  ,"total_beta": "Total de Códigos Beta"
-  ,"total_beta_redeemed": "Códigos Beta Canjeados"
-  ,"nfts_held": "Primos en BD"
-  ,"wallets_with_nfts": "Billeteras con Primos"
-  ,"db_market_cap": "Capitalización BD"
+  "invalid_code_format": "El formato del código es inválido. Debe ser BETA-XXXXXXXX",
+  "active_codes": "Códigos Activos",
+  "redeemed_codes": "Códigos Canjeados",
+  "stats": "Estadísticas",
+  "total_wallets": "Billeteras Únicas",
+  "total_points": "Puntos Totales",
+  "primo_holders": "Primo Holders",
+  "total_beta": "Total de Códigos Beta",
+  "total_beta_redeemed": "Códigos Beta Canjeados",
+  "nfts_held": "Primos en BD",
+  "wallets_with_nfts": "Billeteras con Primos",
+  "db_market_cap": "Capitalización BD",
+  "render_started": "Renderizado 3D iniciado",
+  "render_complete": "Renderizado 3D completo",
+  "notifications": "Notificaciones",
+  "no_notifications": "Sin notificaciones",
+  "render_confirm": "¿Estás seguro de renderizar este NFT en 3D?",
+  "render_thanks": "Renderizado iniciado, gracias. Espera el resultado.",
+  "render_status_not_started": "Renderizado 3D no iniciado",
+  "render_status_in_progress": "Renderizado 3D en progreso",
+  "render_status_done": "Renderizado 3D listo"
 }

--- a/frontend/src/pages/Experiment1.css
+++ b/frontend/src/pages/Experiment1.css
@@ -28,3 +28,18 @@
 .nft.selected {
   border-color: #1976d2;
 }
+
+.nft-wrapper {
+  position: relative;
+}
+
+.status-badge {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+  padding: 2px 4px;
+  font-size: 0.6rem;
+  border-radius: 4px;
+}

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -13,6 +13,7 @@ import CircleIcon from '@mui/icons-material/Circle';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import { Link } from 'react-router-dom';
 import BetaRedeem from '../components/BetaRedeem';
+import { Notification } from '../types';
 
 type SocialLinks = {
   twitter: string;
@@ -58,6 +59,7 @@ const UserProfile: React.FC = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [ballVisible, setBallVisible] = useState(true);
   const [ballAnimating, setBallAnimating] = useState(false);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
 
   useEffect(() => {
     if (profileKey && publicKey) {
@@ -69,6 +71,17 @@ const UserProfile: React.FC = () => {
         .catch(() => setUser(null));
     }
   }, [profileKey, publicKey]);
+
+  useEffect(() => {
+    if (isOwner && publicKey) {
+      api
+        .get('/api/notifications', {
+          headers: { 'X-Public-Key': publicKey.toBase58() },
+        })
+        .then((res) => setNotifications(res.data))
+        .catch(() => setNotifications([]));
+    }
+  }, [isOwner, publicKey]);
 
   useEffect(() => {
     if (profileKey) {
@@ -341,6 +354,22 @@ const fadeOut = keyframes`
           </Button>
         )}
       </Box>
+      {isOwner && (
+        <Box sx={{ mt: 2 }} id="notifications">
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            {t('notifications')}
+          </Typography>
+          {notifications.length === 0 ? (
+            <Typography>{t('no_notifications')}</Typography>
+          ) : (
+            notifications.map((n) => (
+              <Typography key={n.id} sx={{ fontSize: '0.9rem' }}>
+                {n.message}
+              </Typography>
+            ))
+          )}
+        </Box>
+      )}
       {isOwner && <BetaRedeem />}
       {isOwner && (
       <>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,7 @@
+export interface Notification {
+  id: number;
+  publicKey: string;
+  message: string;
+  read: boolean;
+  createdAt: number;
+}


### PR DESCRIPTION
## Summary
- integrate Meshy service and polling job in backend
- store notifications for users and expose REST API
- extend Primo3D model with status and job id
- update Experiment #1 page to show render status and confirm rendering
- add notification badge in header and list on profile page
- add translations and unit tests for new services

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Network is unreachable)*
- `npm test -- --watchAll=false` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad045748c832ab55b5e46016a1c4a