### PR TITLE
Fix missing import in Primo3DResource

### DIFF
--- a/backend/src/main/java/com/primos/resource/Primo3DResource.java
+++ b/backend/src/main/java/com/primos/resource/Primo3DResource.java
@@ -6,6 +6,7 @@ import com.primos.service.Primo3DService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;


### PR DESCRIPTION
## Summary
- add missing `HeaderParam` import to Primo3DResource

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686ae2188ab8832ab276f8e857233415