### PR TITLE
Fix NotificationService ObjectId usage

### DIFF
--- a/backend/src/main/java/com/primos/resource/NotificationResource.java
+++ b/backend/src/main/java/com/primos/resource/NotificationResource.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
+import org.bson.types.ObjectId;
 
 @Path("/api/notifications")
 @Produces(MediaType.APPLICATION_JSON)
@@ -22,7 +23,7 @@ public class NotificationResource {
 
     @PUT
     @Path("/{id}/read")
-    public Notification markRead(@PathParam("id") Long id) {
-        return service.markRead(id);
+    public Notification markRead(@PathParam("id") String id) {
+        return service.markRead(new ObjectId(id));
     }
 }

--- a/backend/src/main/java/com/primos/service/NotificationService.java
+++ b/backend/src/main/java/com/primos/service/NotificationService.java
@@ -3,6 +3,7 @@ package com.primos.service;
 import com.primos.model.Notification;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
+import org.bson.types.ObjectId;
 
 @ApplicationScoped
 public class NotificationService {
@@ -18,7 +19,7 @@ public class NotificationService {
         return Notification.list("publicKey = ?1 order by createdAt desc", publicKey);
     }
 
-    public Notification markRead(Long id) {
+    public Notification markRead(ObjectId id) {
         Notification n = Notification.findById(id);
         if (n != null) {
             n.setRead(true);


### PR DESCRIPTION
## Summary
- handle Mongo ObjectId in `NotificationService.markRead`
- update REST endpoint to parse ObjectId strings

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686aebf0a184832a92ac00c616ebcc83