### PR TITLE
Fix notification dismiss type mismatch

### DIFF
--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -133,7 +133,7 @@ const UserProfile: React.FC = () => {
     setEditDialogOpen(false);
   };
 
-  const handleDismiss = (id: string) => {
+  const handleDismiss = (id: number) => {
     if (!publicKey) return;
     api
       .delete(`/api/notifications/${id}`, {


### PR DESCRIPTION
## Summary
- update the `handleDismiss` helper in `UserProfile` to accept a numeric id

## Testing
- `npm run build` in `frontend`
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686b5dec19a8832a9a88722b89c08244