### PR TITLE
Fix mobile NFT card layout and add Spanish translation

### DIFF
--- a/frontend/src/components/NFTCard.css
+++ b/frontend/src/components/NFTCard.css
@@ -80,13 +80,11 @@
 .nft-info-pills {
   display: flex;
   flex-wrap: nowrap;
-  /* Prevent wrapping */
   gap: 0.7rem;
   margin-bottom: 0.2rem;
   width: 100%;
   justify-content: flex-start;
   overflow-x: auto;
-  /* Allow horizontal scroll if needed */
 }
 
 .nft-info-pill {
@@ -217,6 +215,12 @@
     border-radius: 0.75rem;
     box-shadow: 0 8px 40px rgba(0, 0, 0, 0.18);
     position: relative;
+  }
+
+  .nft-info-pills {
+    flex-wrap: wrap;
+    justify-content: center;
+    overflow-x: visible;
   }
 }
 

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -158,6 +158,7 @@
   "nfts_held": "Primos en BD",
   "wallets_with_nfts": "Billeteras con Primos",
   "db_market_cap": "Capitalización BD",
+  "experiment1_select": "Selecciona uno de tus Primo NFTs para renderizar un modelo 3D.",
   "render_started": "Renderizado 3D iniciado para Primo",
   "render_complete": "Renderizado 3D completo",
   "notifications": "Notificaciones",


### PR DESCRIPTION
## Summary
- add Spanish translation for Experiment 1 select message
- tweak NFT card CSS for better mobile pill layout

## Testing
- `CI=true npx craco test --watchAll=false` *(fails: Cannot find module '@testing-library/react')*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c911f1914832a9dabfae935c1912e