### PR TITLE
Improve mobile UI with navigation

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,23 +1,25 @@
 import React from 'react';
-import { SafeAreaView, Text, StyleSheet } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { StatusBar } from 'expo-status-bar';
 import { useTranslation } from 'react-i18next';
 import './i18n';
 
+import HomeScreen from './screens/HomeScreen';
+import ProfileScreen from './screens/ProfileScreen';
+
+const Tab = createBottomTabNavigator();
+
 export default function App() {
   const { t } = useTranslation();
+
   return (
-    <SafeAreaView style={styles.container}>
-      <Text>{t('mobile_welcome')}</Text>
+    <NavigationContainer>
       <StatusBar style="auto" />
-    </SafeAreaView>
+      <Tab.Navigator>
+        <Tab.Screen name="Home" component={HomeScreen} options={{ title: t('home') }} />
+        <Tab.Screen name="Profile" component={ProfileScreen} options={{ title: t('profile') }} />
+      </Tab.Navigator>
+    </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center'
-  }
-});

--- a/mobile/locales/en.json
+++ b/mobile/locales/en.json
@@ -1,4 +1,6 @@
 {
   "mobile_welcome": "Welcome to the Primos mobile app!",
-  "render_started": "3D rendering started for Primo"
+  "render_started": "3D rendering started for Primo",
+  "home": "Home",
+  "profile": "Profile"
 }

--- a/mobile/locales/es.json
+++ b/mobile/locales/es.json
@@ -1,4 +1,6 @@
 {
-  "mobile_welcome": "\u00a1Bienvenido a la app m\u00f3vil de Primos!",
-  "render_started": "Renderizado 3D iniciado para Primo"
+  "mobile_welcome": "¡Bienvenido a la app móvil de Primos!",
+  "render_started": "Renderizado 3D iniciado para Primo",
+  "home": "Inicio",
+  "profile": "Perfil"
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,7 +16,11 @@
     "react-dom": "18.2.0",
     "react-native": "0.72.3",
     "i18next": "^21.10.0",
-    "react-i18next": "^11.18.6"
+    "react-i18next": "^11.18.6",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-screens": "^3.22.0",
+    "react-native-safe-area-context": "^4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+const HomeScreen = () => {
+  const { t } = useTranslation();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{t('mobile_welcome')}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 18,
+  },
+});
+
+export default HomeScreen;

--- a/mobile/screens/ProfileScreen.js
+++ b/mobile/screens/ProfileScreen.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+const ProfileScreen = () => {
+  const { t } = useTranslation();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{t('profile')}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 18,
+  },
+});
+
+export default ProfileScreen;


### PR DESCRIPTION
## Summary
- add bottom tab navigation in mobile app
- add Home and Profile screens
- translate new labels
- include navigation dependencies

## Testing
- `npm test` in `frontend` *(fails: craco not found)*
- `mvn test` in `backend` *(fails: command not found)*
- `npm test` in `mobile` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c99c29400832a98845b98247ddade