### PR TITLE
Add time column to activity panel

### DIFF
--- a/frontend/src/components/Activity.css
+++ b/frontend/src/components/Activity.css
@@ -98,6 +98,12 @@
   min-width: 90px;
 }
 
+.activity-time {
+  color: #555;
+  font-size: 0.8rem;
+  min-width: 110px;
+}
+
 .activity-price {
   background: #fff;
   border-radius: 0.28rem; 

--- a/frontend/src/components/Activity.tsx
+++ b/frontend/src/components/Activity.tsx
@@ -169,6 +169,9 @@ const Activity: React.FC = () => {
               <span className="activity-type">{typeLabels[item.type] || item.type}</span>
             )}
             <span className="activity-nft">{item.nftName}</span>
+            <span className="activity-time">
+              {new Date(item.time).toLocaleString()}
+            </span>
             {item.price && (
               <span className="activity-price">
                 {item.price.toFixed(3)} SOL

--- a/frontend/src/components/__tests__/Activity.test.tsx
+++ b/frontend/src/components/__tests__/Activity.test.tsx
@@ -56,4 +56,24 @@ describe('Activity component', () => {
       expect(screen.getByText('Primo 1')).toBeTruthy();
     });
   });
+
+  test('displays activity time', async () => {
+    const { fetchMagicEdenActivity } = require('../utils/magiceden');
+    (fetchMagicEdenActivity as jest.Mock).mockResolvedValueOnce([
+      {
+        tokenMint: 'mint2',
+        type: 'sale',
+        price: 1,
+        blockTime: 1,
+        signature: 'sig2',
+      },
+    ]);
+    render(
+      <I18nextProvider i18n={i18n}>
+        <Activity />
+      </I18nextProvider>
+    );
+    const timeString = new Date(1000).toLocaleString();
+    expect(await screen.findByText(timeString)).toBeTruthy();
+  });
 });

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -66,6 +66,7 @@
   "activity_mint": "Minted",
   "activity_from": "From",
   "activity_to": "To",
+  "activity_time": "Time",
   "primo_labs": "Primo Labs",
   "primo_labs_login_prompt": "Please login to access Primo Labs",
   "primo_labs_desc": "Primo Labs will function as a launchpad and innovation hub for new features, NFT utilities, and community experiments. Stay tuned for exclusive tools and early access to upcoming projects.",

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -66,6 +66,7 @@
   "activity_mint": "Minteado",
   "activity_from": "De",
   "activity_to": "Para",
+  "activity_time": "Hora",
   "primo_labs": "Primo Labs",
   "primo_labs_login_prompt": "Por favor inicia sesión para acceder a Primo Labs",
   "primo_labs_desc": "Primo Labs funcionará como una plataforma de lanzamiento y centro de innovación para nuevas funciones, utilidades NFT y experimentos comunitarios. Próximamente: herramientas exclusivas y acceso anticipado a nuevos proyectos.",


### PR DESCRIPTION
## Summary
- display timestamp for each activity entry
- translate new time label in Spanish and English locales
- test rendering of activity time

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm test -- --watchAll=false` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878875d9a80832a9de5ceb65d5d5eb0