### PR TITLE
Add Magic Eden transaction handling

### DIFF
--- a/frontend/src/components/NFTCard.tsx
+++ b/frontend/src/components/NFTCard.tsx
@@ -15,6 +15,11 @@ export type MarketNFT = {
   variant: string;
   rank: number | null;
   attributes?: { trait_type: string; value: string }[];
+  tokenAta?: string;
+  seller?: string;
+  auctionHouse?: string;
+  sellerReferral?: string;
+  sellerExpiry?: number;
 };
 
 interface NFTCardProps {

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -174,5 +174,7 @@
   "dismiss": "Dismiss",
   "dismiss_all": "Dismiss All",
   "download_3d": "Download 3D",
-  "has_3d": "3D available"
+  "has_3d": "3D available",
+  "tx_success": "Transaction sent!",
+  "tx_failed": "Transaction failed"
 }

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -173,5 +173,7 @@
   "dismiss": "Descartar",
   "dismiss_all": "Descartar todo",
   "download_3d": "Descargar 3D",
-  "has_3d": "3D disponible"
+  "has_3d": "3D disponible",
+  "tx_success": "¡Transacción enviada!",
+  "tx_failed": "Transacción fallida"
 }

--- a/frontend/src/utils/__tests__/transaction.test.ts
+++ b/frontend/src/utils/__tests__/transaction.test.ts
@@ -1,0 +1,38 @@
+import { executeBuyNow, BuyNowListing } from '../transaction';
+import { getBuyNowInstructions } from '../magiceden';
+import { Transaction } from '@solana/web3.js';
+
+jest.mock('../magiceden', () => ({
+  getBuyNowInstructions: jest.fn(),
+}));
+
+jest.mock('@solana/web3.js', () => ({
+  Transaction: { from: jest.fn(() => ({ decoded: true })) },
+}));
+
+describe('executeBuyNow', () => {
+  test('sends transaction', async () => {
+    (getBuyNowInstructions as jest.Mock).mockResolvedValue({
+      txSigned: { data: Buffer.from('tx').toString('base64') },
+    });
+    const sendTransaction = jest.fn().mockResolvedValue('sig');
+    const wallet: any = {
+      publicKey: { toBase58: () => 'buyer' },
+      sendTransaction,
+    };
+    const connection: any = {
+      confirmTransaction: jest.fn().mockResolvedValue(null),
+    };
+    const listing: BuyNowListing = {
+      tokenMint: 'mint',
+      tokenAta: 'ata',
+      seller: 'seller',
+      price: 1,
+      auctionHouse: 'ah',
+    };
+    const sig = await executeBuyNow(connection, wallet, listing);
+    expect(getBuyNowInstructions).toHaveBeenCalled();
+    expect(sendTransaction).toHaveBeenCalled();
+    expect(sig).toBe('sig');
+  });
+});

--- a/frontend/src/utils/transaction.ts
+++ b/frontend/src/utils/transaction.ts
@@ -1,0 +1,42 @@
+import { Connection, Transaction } from '@solana/web3.js';
+import { WalletContextState } from '@solana/wallet-adapter-react';
+import { getBuyNowInstructions } from './magiceden';
+
+export interface BuyNowListing {
+  tokenMint: string;
+  tokenAta: string;
+  seller: string;
+  price: number;
+  auctionHouse: string;
+  sellerReferral?: string;
+  sellerExpiry?: number;
+}
+
+export const executeBuyNow = async (
+  connection: Connection,
+  wallet: WalletContextState,
+  listing: BuyNowListing
+): Promise<string> => {
+  const buyer = wallet.publicKey?.toBase58();
+  if (!buyer) throw new Error('Wallet not connected');
+
+  const params: Record<string, string> = {
+    buyer,
+    seller: listing.seller,
+    tokenMint: listing.tokenMint,
+    tokenATA: listing.tokenAta,
+    price: listing.price.toString(),
+    auctionHouseAddress: listing.auctionHouse,
+  };
+  if (listing.sellerReferral) params.sellerReferral = listing.sellerReferral;
+  if (listing.sellerExpiry !== undefined)
+    params.sellerExpiry = listing.sellerExpiry.toString();
+
+  const resp = await getBuyNowInstructions(params);
+  const encoded = resp.txSigned?.data;
+  if (!encoded) throw new Error('Invalid response');
+  const tx = Transaction.from(Buffer.from(encoded, 'base64'));
+  const sig = await wallet.sendTransaction(tx, connection);
+  await connection.confirmTransaction(sig, 'confirmed');
+  return sig;
+};


### PR DESCRIPTION
## Summary
- log Magic Eden buy-now requests and errors on the backend
- extend market NFT definitions with listing metadata
- wire buy button to execute a Magic Eden transaction
- add utility for executing buy transactions
- add tests and translations for transaction flow

## Testing
- `npm test --silent` *(fails: craco not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878885f927c832aa9fad4868baf7cfe