### PR TITLE
Add listing capability via Magic Eden API

### DIFF
--- a/backend/src/main/java/com/primos/resource/MagicEdenListResource.java
+++ b/backend/src/main/java/com/primos/resource/MagicEdenListResource.java
@@ -1,0 +1,81 @@
+package com.primos.resource;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.ProxySelector;
+import java.net.InetSocketAddress;
+
+/**
+ * Fetches "list" instructions from the Magic Eden API. The backend adds the
+ * required API key so the frontend does not expose it.
+ */
+@Path("/api/magiceden/list")
+@Produces(MediaType.APPLICATION_JSON)
+public class MagicEdenListResource {
+
+    private static final Logger LOG = Logger.getLogger(MagicEdenListResource.class);
+
+    private static final String API_BASE = "https://api-mainnet.magiceden.dev";
+    private static final String API_KEY = System.getenv("MAGICEDEN_API_KEY");
+    private static final HttpClient CLIENT = createClient();
+
+    private static HttpClient createClient() {
+        String proxy = System.getenv("https_proxy");
+        if (proxy == null || proxy.isEmpty()) {
+            proxy = System.getenv("HTTPS_PROXY");
+        }
+        if (proxy != null && !proxy.isEmpty()) {
+            try {
+                URI uri = URI.create(proxy);
+                return HttpClient.newBuilder()
+                        .proxy(ProxySelector.of(new InetSocketAddress(uri.getHost(), uri.getPort())))
+                        .build();
+            } catch (Exception ignored) {
+            }
+        }
+        return HttpClient.newHttpClient();
+    }
+
+    @GET
+    public Response list(@QueryParam("seller") String seller,
+                         @QueryParam("tokenMint") String tokenMint,
+                         @QueryParam("tokenATA") String tokenATA,
+                         @QueryParam("price") String price,
+                         @QueryParam("auctionHouseAddress") String auctionHouse)
+            throws IOException, InterruptedException {
+        StringBuilder url = new StringBuilder(API_BASE)
+                .append("/v2/instructions/sell?seller=").append(seller)
+                .append("&tokenMint=").append(tokenMint)
+                .append("&tokenATA=").append(tokenATA)
+                .append("&price=").append(price)
+                .append("&auctionHouseAddress=").append(auctionHouse);
+        LOG.infof("Requesting list tx seller=%s tokenMint=%s price=%s", seller, tokenMint, price);
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(url.toString()))
+                .GET();
+        if (API_KEY != null && !API_KEY.isBlank()) {
+            builder.header("Authorization", "Bearer " + API_KEY);
+        }
+        HttpResponse<String> resp;
+        try {
+            resp = CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        } catch (IOException | InterruptedException e) {
+            LOG.error("Failed to fetch list instructions", e);
+            throw e;
+        }
+
+        int status = resp.statusCode() == 304 ? 200 : resp.statusCode();
+        LOG.debugf("Magic Eden response status: %d", status);
+        return Response.status(status).entity(resp.body()).build();
+    }
+}

--- a/frontend/src/locales/__tests__/translations.test.ts
+++ b/frontend/src/locales/__tests__/translations.test.ts
@@ -1,0 +1,10 @@
+import en from '../en/en.json';
+import es from '../es/es.json';
+
+describe('translation keys', () => {
+  test('es matches en keys', () => {
+    const enKeys = Object.keys(en).sort();
+    const esKeys = Object.keys(es).sort();
+    expect(esKeys).toEqual(enKeys);
+  });
+});

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -162,6 +162,7 @@
   "wallets_with_nfts": "Billeteras con Primos",
   "db_market_cap": "Capitalización BD",
   "experiment1_select": "Selecciona uno de tus Primo NFTs para renderizar un modelo 3D.",
+  "experiment1_rendering": "Renderizando...",
   "render_started": "Renderizado 3D iniciado para Primo",
   "render_complete": "Renderizado 3D completo",
   "notifications": "Notificaciones",

--- a/frontend/src/utils/__tests__/magiceden.test.ts
+++ b/frontend/src/utils/__tests__/magiceden.test.ts
@@ -1,4 +1,4 @@
-import { getMagicEdenStats, getMagicEdenHolderStats, fetchMagicEdenListings, fetchMagicEdenActivity, getTraitFloorPrice, getBuyNowInstructions } from '../magiceden';
+import { getMagicEdenStats, getMagicEdenHolderStats, fetchMagicEdenListings, fetchMagicEdenActivity, getTraitFloorPrice, getBuyNowInstructions, getListInstructions } from '../magiceden';
 
 describe('magiceden utilities', () => {
   afterEach(() => {
@@ -60,6 +60,16 @@ describe('magiceden utilities', () => {
     const params = { buyer: 'A', seller: 'B' };
     const data = await getBuyNowInstructions(params);
     expect(fetchMock).toHaveBeenCalledWith('/api/magiceden/buy_now?buyer=A&seller=B');
+    expect(data.txSigned.data[0]).toBe(1);
+  });
+
+  test('getListInstructions calls backend', async () => {
+    const response = { ok: true, json: async () => ({ txSigned: { data: [1] } }) };
+    const fetchMock = jest.fn().mockResolvedValue(response);
+    (global as any).fetch = fetchMock;
+    const params = { seller: 'A', tokenMint: 'B' };
+    const data = await getListInstructions(params);
+    expect(fetchMock).toHaveBeenCalledWith('/api/magiceden/list?seller=A&tokenMint=B');
     expect(data.txSigned.data[0]).toBe(1);
   });
 });

--- a/frontend/src/utils/__tests__/transaction.test.ts
+++ b/frontend/src/utils/__tests__/transaction.test.ts
@@ -1,9 +1,10 @@
-import { executeBuyNow, BuyNowListing } from '../transaction';
-import { getBuyNowInstructions } from '../magiceden';
+import { executeBuyNow, BuyNowListing, executeList, ListNFT } from '../transaction';
+import { getBuyNowInstructions, getListInstructions } from '../magiceden';
 import { Transaction } from '@solana/web3.js';
 
 jest.mock('../magiceden', () => ({
   getBuyNowInstructions: jest.fn(),
+  getListInstructions: jest.fn(),
 }));
 
 jest.mock('@solana/web3.js', () => ({
@@ -32,6 +33,32 @@ describe('executeBuyNow', () => {
     };
     const sig = await executeBuyNow(connection, wallet, listing);
     expect(getBuyNowInstructions).toHaveBeenCalled();
+    expect(sendTransaction).toHaveBeenCalled();
+    expect(sig).toBe('sig');
+  });
+});
+
+describe('executeList', () => {
+  test('sends transaction', async () => {
+    (getListInstructions as jest.Mock).mockResolvedValue({
+      txSigned: { data: Buffer.from('tx').toString('base64') },
+    });
+    const sendTransaction = jest.fn().mockResolvedValue('sig');
+    const wallet: any = {
+      publicKey: { toBase58: () => 'seller' },
+      sendTransaction,
+    };
+    const connection: any = {
+      confirmTransaction: jest.fn().mockResolvedValue(null),
+    };
+    const nft: ListNFT = {
+      tokenMint: 'mint',
+      tokenAta: 'ata',
+      price: 1,
+      auctionHouse: 'ah',
+    };
+    const sig = await executeList(connection, wallet, nft);
+    expect(getListInstructions).toHaveBeenCalled();
     expect(sendTransaction).toHaveBeenCalled();
     expect(sig).toBe('sig');
   });

--- a/frontend/src/utils/magiceden.ts
+++ b/frontend/src/utils/magiceden.ts
@@ -263,3 +263,19 @@ export const getBuyNowInstructions = async (
   }
   return res.json();
 };
+
+/**
+ * Requests Magic Eden's listing instructions via the backend.
+ * @param params Query parameters for the instruction builder
+ * @returns JSON response from Magic Eden
+ */
+export const getListInstructions = async (
+  params: Record<string, string>
+): Promise<any> => {
+  const qs = new URLSearchParams(params).toString();
+  const res = await fetch(`/api/magiceden/list?${qs}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch list instructions');
+  }
+  return res.json();
+};


### PR DESCRIPTION
## Summary
- implement backend endpoint for Magic Eden listing instructions
- extend MagicEden utilities with `getListInstructions`
- add `executeList` helper for listing NFTs
- ensure Spanish translations match English
- provide unit tests for translation files and new functions

## Testing
- `npm test --silent --runInBand` *(fails: craco not found)*
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68788e510058832a99a16a5e008d5a23