### PR TITLE
Improve mobile activity panel layout

### DIFF
--- a/frontend/src/components/Activity.css
+++ b/frontend/src/components/Activity.css
@@ -4,6 +4,7 @@
   box-shadow: -4px 0 24px rgba(226, 194, 117, 0.08);
   padding: 1.5rem 1rem 1rem 1.5rem;
   overflow-y: auto;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   min-height: 100%;
@@ -96,6 +97,10 @@
   font-weight: 500;
   color: #333;
   min-width: 90px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
 }
 
 .activity-time {
@@ -127,5 +132,26 @@
 @media (max-width: 1100px) {
   .activity-desktop {
     display: none;
+  }
+}
+
+@media (max-width: 700px) {
+  .activity-panel {
+    width: 100vw;
+  }
+
+  .activity-type,
+  .activity-nft,
+  .activity-time,
+  .activity-price {
+    min-width: 0;
+  }
+
+  .activity-type {
+    min-width: 40px;
+  }
+
+  .activity-time {
+    min-width: 90px;
   }
 }

--- a/frontend/src/components/Activity.tsx
+++ b/frontend/src/components/Activity.tsx
@@ -34,6 +34,7 @@ const Activity: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const isNarrow = useMediaQuery('(max-width:700px)');
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
 
@@ -227,7 +228,12 @@ const Activity: React.FC = () => {
               open={open}
               onClose={() => setOpen(false)}
               ModalProps={{ keepMounted: true }}
-              sx={{ [`& .MuiDrawer-paper`]: { width: 340, boxSizing: 'border-box' } }}
+              sx={{
+                [`& .MuiDrawer-paper`]: {
+                  width: isNarrow ? '100vw' : 340,
+                  boxSizing: 'border-box',
+                },
+              }}
             >
               {panelContent}
             </Drawer>


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling in activity panel
- adjust NFT column to avoid overflow
- support narrow screens and handle drawer width

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878976f90a0832aa46f4aa8623ece1b