### PR TITLE
Improve mobile activity panel

### DIFF
--- a/frontend/src/components/Activity.tsx
+++ b/frontend/src/components/Activity.tsx
@@ -6,6 +6,7 @@ import ListItem from '@mui/material/ListItem';
 import IconButton from '@mui/material/IconButton';
 import Drawer from '@mui/material/Drawer';
 import HistoryIcon from '@mui/icons-material/History';
+import CloseIcon from '@mui/icons-material/Close';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
@@ -124,10 +125,17 @@ const Activity: React.FC = () => {
   };
 
   const panelContent = (
-    <Box component="aside" className={`activity-panel${isMobile ? '' : ' activity-desktop'}`}> 
-      <Typography variant="h6" component="h3" className="activity-title">
-        {t('activity')}
-      </Typography>
+    <Box component="aside" className={`activity-panel${isMobile ? '' : ' activity-desktop'}`}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="h6" component="h3" className="activity-title">
+          {t('activity')}
+        </Typography>
+        {isMobile && (
+          <IconButton aria-label="close activity" onClick={() => setOpen(false)} size="small">
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        )}
+      </Box>
       <List className="activity-list">
         {activity.map((item, idx) => (
           <ListItem
@@ -206,7 +214,7 @@ const Activity: React.FC = () => {
         <>
           <IconButton
             aria-label="open activity"
-            onClick={() => setOpen(true)}
+            onClick={() => setOpen((prev) => !prev)}
             className="activity-mobile-btn"
             sx={{
               position: 'fixed',
@@ -232,6 +240,8 @@ const Activity: React.FC = () => {
                 [`& .MuiDrawer-paper`]: {
                   width: isNarrow ? '100vw' : 340,
                   boxSizing: 'border-box',
+                  top: 80,
+                  height: 'calc(100vh - 80px)',
                 },
               }}
             >

--- a/frontend/src/components/__tests__/Activity.test.tsx
+++ b/frontend/src/components/__tests__/Activity.test.tsx
@@ -76,4 +76,33 @@ describe('Activity component', () => {
     const timeString = new Date(1000).toLocaleString();
     expect(await screen.findByText(timeString)).toBeTruthy();
   });
+
+  test('closes panel when close button clicked', async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <Activity />
+      </I18nextProvider>
+    );
+    fireEvent.click(screen.getByLabelText(/open activity/i));
+    const closeBtn = await screen.findByLabelText(/close activity/i);
+    fireEvent.click(closeBtn);
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/close activity/i)).toBeNull();
+    });
+  });
+
+  test('toggles panel with action icon', async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <Activity />
+      </I18nextProvider>
+    );
+    const toggleBtn = screen.getByLabelText(/open activity/i);
+    fireEvent.click(toggleBtn);
+    expect(await screen.findByLabelText(/close activity/i)).toBeTruthy();
+    fireEvent.click(toggleBtn);
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/close activity/i)).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add close icon to activity side panel
- allow activity toggle icon to close panel
- offset drawer below navigation bar on mobile
- add tests for closing the activity panel

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm test -- --watchAll=false` *(fails: `craco` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789dd2a034832aa382feb3459662e6