### PR TITLE
Fix sticky header on mobile activity panel

### DIFF
--- a/frontend/src/components/Activity.css
+++ b/frontend/src/components/Activity.css
@@ -29,6 +29,13 @@
   letter-spacing: 0.04em;
 }
 
+.activity-header {
+  position: sticky;
+  top: 0;
+  background: #f5f5f8;
+  z-index: 1;
+}
+
 .activity-list {
   list-style: none;
   padding: 0;

--- a/frontend/src/components/Activity.tsx
+++ b/frontend/src/components/Activity.tsx
@@ -126,7 +126,10 @@ const Activity: React.FC = () => {
 
   const panelContent = (
     <Box component="aside" className={`activity-panel${isMobile ? '' : ' activity-desktop'}`}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box
+        className="activity-header"
+        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+      >
         <Typography variant="h6" component="h3" className="activity-title">
           {t('activity')}
         </Typography>


### PR DESCRIPTION
## Summary
- make the activity panel header sticky on mobile so users always see the title and close button

## Testing
- `npm test --prefix frontend` *(fails: craco not found / dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878e9b3bb64832aaec4c04ec0dee34c