### PR TITLE
Add transaction recording service

### DIFF
--- a/backend/src/main/java/com/primos/model/Transaction.java
+++ b/backend/src/main/java/com/primos/model/Transaction.java
@@ -1,0 +1,89 @@
+package com.primos.model;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+
+@MongoEntity(collection = "transactions")
+public class Transaction extends PanacheMongoEntity {
+    private String txId;
+    private String buyer;
+    private String seller;
+    private String mint;
+    private Double price;
+    private String collection;
+    private String source;
+    private String timestamp;
+    private String status;
+
+    public String getTxId() {
+        return txId;
+    }
+
+    public void setTxId(String txId) {
+        this.txId = txId;
+    }
+
+    public String getBuyer() {
+        return buyer;
+    }
+
+    public void setBuyer(String buyer) {
+        this.buyer = buyer;
+    }
+
+    public String getSeller() {
+        return seller;
+    }
+
+    public void setSeller(String seller) {
+        this.seller = seller;
+    }
+
+    public String getMint() {
+        return mint;
+    }
+
+    public void setMint(String mint) {
+        this.mint = mint;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public void setCollection(String collection) {
+        this.collection = collection;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/backend/src/main/java/com/primos/resource/TransactionDTO.java
+++ b/backend/src/main/java/com/primos/resource/TransactionDTO.java
@@ -1,0 +1,10 @@
+package com.primos.resource;
+
+public class TransactionDTO {
+    public String txId;
+    public String mint;
+    public String buyer;
+    public String collection;
+    public String source;
+    public String timestamp;
+}

--- a/backend/src/main/java/com/primos/resource/TransactionResource.java
+++ b/backend/src/main/java/com/primos/resource/TransactionResource.java
@@ -1,0 +1,24 @@
+package com.primos.resource;
+
+import com.primos.service.TransactionService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/api/transactions")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class TransactionResource {
+
+    @Inject TransactionService service;
+
+    @POST
+    public Response recordTx(TransactionDTO tx) {
+        service.recordTransaction(tx);
+        return Response.status(Response.Status.CREATED).build();
+    }
+}

--- a/backend/src/main/java/com/primos/service/TransactionService.java
+++ b/backend/src/main/java/com/primos/service/TransactionService.java
@@ -1,0 +1,95 @@
+package com.primos.service;
+
+import com.primos.model.Transaction;
+import com.primos.resource.TransactionDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.ProxySelector;
+import java.net.InetSocketAddress;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class TransactionService {
+    private static final Logger LOG = Logger.getLogger(TransactionService.class.getName());
+    private static final String API_BASE = "https://api-mainnet.magiceden.dev";
+    private static final String COLLECTION = System.getenv().getOrDefault("REACT_APP_PRIMOS_COLLECTION", "primos");
+    private static final HttpClient CLIENT = createClient();
+
+    private static HttpClient createClient() {
+        String proxy = System.getenv("https_proxy");
+        if (proxy == null || proxy.isEmpty()) {
+            proxy = System.getenv("HTTPS_PROXY");
+        }
+        if (proxy != null && !proxy.isEmpty()) {
+            try {
+                URI uri = URI.create(proxy);
+                return HttpClient.newBuilder()
+                        .proxy(ProxySelector.of(new InetSocketAddress(uri.getHost(), uri.getPort())))
+                        .build();
+            } catch (Exception ignored) {
+            }
+        }
+        return HttpClient.newHttpClient();
+    }
+
+    public Transaction recordTransaction(TransactionDTO dto) {
+        Transaction tx = new Transaction();
+        tx.setTxId(dto.txId);
+        tx.setBuyer(dto.buyer);
+        tx.setMint(dto.mint);
+        tx.setCollection(dto.collection);
+        tx.setSource(dto.source);
+        tx.setTimestamp(dto.timestamp);
+        tx.setStatus("pending");
+        tx.persist();
+        enrich(tx);
+        return tx;
+    }
+
+    public void updateStatus(Transaction tx) {
+        if (tx == null || "confirmed".equalsIgnoreCase(tx.getStatus())) {
+            return;
+        }
+        enrich(tx);
+    }
+
+    private void enrich(Transaction tx) {
+        try {
+            String url = String.format("%s/v2/collections/%s/activities?offset=0&limit=20", API_BASE, COLLECTION);
+            HttpRequest req = HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
+            HttpResponse<String> resp = CLIENT.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200 || resp.body() == null || resp.body().isBlank()) {
+                return;
+            }
+            try (JsonReader reader = Json.createReader(new StringReader(resp.body()))) {
+                JsonArray arr = reader.readArray();
+                for (int i = 0; i < arr.size(); i++) {
+                    JsonObject obj = arr.getJsonObject(i);
+                    String txId = obj.getString("txId", "");
+                    String mint = obj.getString("mint", "");
+                    if (tx.getTxId().equals(txId) || tx.getMint().equals(mint)) {
+                        tx.setSeller(obj.getString("seller", null));
+                        if (obj.containsKey("price")) {
+                            try {
+                                tx.setPrice(obj.getJsonNumber("price").doubleValue());
+                            } catch (Exception ignore) {}
+                        }
+                        tx.setStatus("confirmed");
+                        tx.persistOrUpdate();
+                        return;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warning("Failed to enrich transaction: " + e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/primos/service/TransactionStatusJob.java
+++ b/backend/src/main/java/com/primos/service/TransactionStatusJob.java
@@ -1,0 +1,20 @@
+package com.primos.service;
+
+import com.primos.model.Transaction;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import io.quarkus.scheduler.Scheduled;
+import java.util.List;
+
+@ApplicationScoped
+public class TransactionStatusJob {
+    @Inject TransactionService service;
+
+    @Scheduled(every = "60s")
+    void poll() {
+        List<Transaction> pending = Transaction.list("status", "pending");
+        for (Transaction tx : pending) {
+            service.updateStatus(tx);
+        }
+    }
+}

--- a/backend/src/test/java/com/primos/resource/TransactionResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/TransactionResourceTest.java
@@ -1,0 +1,26 @@
+package com.primos.resource;
+
+import com.primos.model.Transaction;
+import com.primos.service.TransactionService;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TransactionResourceTest {
+    @Test
+    public void testRecordTransaction() {
+        TransactionResource res = new TransactionResource();
+        // Manually inject service
+        res.service = new TransactionService();
+        TransactionDTO dto = new TransactionDTO();
+        dto.txId = "sig1";
+        dto.mint = "mint1";
+        dto.buyer = "buyer1";
+        dto.collection = "primos";
+        dto.source = "magiceden";
+        dto.timestamp = "2024-01-01T00:00:00Z";
+        res.recordTx(dto);
+        Transaction tx = Transaction.find("txId", "sig1").firstResult();
+        assertNotNull(tx);
+        assertEquals("buyer1", tx.getBuyer());
+    }
+}

--- a/backend/src/test/java/com/primos/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TransactionServiceTest.java
@@ -1,0 +1,25 @@
+package com.primos.service;
+
+import com.primos.model.Transaction;
+import com.primos.resource.TransactionDTO;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TransactionServiceTest {
+    @Test
+    public void testRecordTransaction() {
+        TransactionService svc = new TransactionService();
+        TransactionDTO dto = new TransactionDTO();
+        dto.txId = "abc123";
+        dto.mint = "mint2";
+        dto.buyer = "buyer2";
+        dto.collection = "primos";
+        dto.source = "magiceden";
+        dto.timestamp = "2024-01-02T00:00:00Z";
+        Transaction tx = svc.recordTransaction(dto);
+        assertNotNull(tx.getId());
+        assertEquals("abc123", tx.getTxId());
+        Transaction stored = Transaction.find("txId", "abc123").firstResult();
+        assertNotNull(stored);
+    }
+}


### PR DESCRIPTION
## Summary
- create Mongo entity for transactions
- add transaction DTO and resource for POST endpoint
- implement service to enrich transactions from Magic Eden
- schedule job to confirm pending transactions
- add unit tests for new resource and service

## Testing
- `mvn test` *(fails: Could not resolve Maven dependencies)*
- `npm test -- --watchAll=false` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792fee88e4832abde50603c6c1471b