### PR TITLE
Open profiles to public

### DIFF
--- a/backend/src/main/java/com/primos/service/UserService.java
+++ b/backend/src/main/java/com/primos/service/UserService.java
@@ -5,16 +5,12 @@ import java.util.List;
 import com.primos.model.User;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 
 @ApplicationScoped
 public class UserService {
 
     public User getUser(String publicKey, String walletKey) {
-        if (walletKey == null || walletKey.isEmpty()) {
-            throw new ForbiddenException();
-        }
         User user = User.find("publicKey", publicKey).firstResult();
         if (user == null) {
             throw new NotFoundException();
@@ -23,9 +19,6 @@ public class UserService {
     }
 
     public List<User> getDaoMembers(String walletKey) {
-        if (walletKey == null || walletKey.isEmpty()) {
-            throw new ForbiddenException();
-        }
         return User.list("primoHolder", true);
     }
 

--- a/backend/src/test/java/com/primos/resource/UserResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/UserResourceTest.java
@@ -48,7 +48,7 @@ public class UserResourceTest {
     }
 
     @Test
-    public void testGetUserForbiddenWithoutHeader() {
+    public void testGetUserWithoutHeader() {
         UserResource resource = new UserResource();
         LoginRequest req = new LoginRequest();
         req.publicKey = "dummy1";
@@ -57,8 +57,8 @@ public class UserResourceTest {
         code.persist();
         req.betaCode = "B2";
         resource.login(req);
-        assertThrows(jakarta.ws.rs.ForbiddenException.class,
-                () -> resource.getUser("dummy1", null));
+        com.primos.model.User user = resource.getUser("dummy1", null);
+        assertNotNull(user);
     }
 
     @Test
@@ -91,9 +91,18 @@ public class UserResourceTest {
     }
 
     @Test
-    public void testGetDaoMembersForbiddenWithoutHeader() {
+    public void testGetDaoMembersWithoutHeader() {
         UserResource resource = new UserResource();
-        assertThrows(jakarta.ws.rs.ForbiddenException.class, () -> resource.getDaoMembers(null));
+        LoginRequest req = new LoginRequest();
+        req.publicKey = "member2";
+        req.primoHolder = true;
+        com.primos.model.BetaCode code = new com.primos.model.BetaCode();
+        code.setCode("B4a");
+        code.persist();
+        req.betaCode = "B4a";
+        resource.login(req);
+        java.util.List<com.primos.model.User> members = resource.getDaoMembers(null);
+        assertFalse(members.isEmpty());
     }
 
     @Test

--- a/frontend/src/components/SidebarNav.tsx
+++ b/frontend/src/components/SidebarNav.tsx
@@ -47,7 +47,7 @@ const SidebarNav: React.FC = () => {
       to: '/primos',
       icon: <PeopleIcon />,
       label: t('primos_title'),
-      show: publicKey && (isHolder || betaRedeemed) && userExists,
+      show: true,
     },
   ];
 

--- a/frontend/src/pages/Primos.tsx
+++ b/frontend/src/pages/Primos.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useWallet } from '@solana/wallet-adapter-react';
-import { usePrimoHolder } from '../contexts/PrimoHolderContext';
-import * as Dialog from '@radix-ui/react-dialog';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Avatar from '@mui/material/Avatar';
@@ -25,20 +23,14 @@ interface Member {
 
 const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
   const wallet = useWallet();
-  const { isHolder } = usePrimoHolder();
-  const isConnected = connected ?? (wallet.connected && isHolder);
   const { t } = useTranslation();
   const [members, setMembers] = useState<Member[]>([]);
   const [search, setSearch] = useState('');
 
   useEffect(() => {
-    if (!isConnected) return;
-
     async function fetchMembers() {
       try {
-        const res = await api.get<Member[]>('/api/user/primos', {
-          headers: { 'X-Public-Key': wallet.publicKey?.toBase58() },
-        });
+        const res = await api.get<Member[]>('/api/user/primos');
         const sorted = res.data.slice().sort((a: Member, b: Member) => b.pesos - a.pesos);
         const enriched = await Promise.all(
           sorted.map(async (m) => {
@@ -61,18 +53,7 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
       }
     }
     fetchMembers();
-  }, [isConnected]);
-
-  if (!isConnected) {
-    return (
-      <Dialog.Root open>
-        <Dialog.Overlay className="dialog-overlay" />
-        <Dialog.Content className="dialog-content">
-          <Typography variant="h6">{t('primos_login_prompt')}</Typography>
-        </Dialog.Content>
-      </Dialog.Root>
-    );
-  }
+  }, []);
 
   const filtered = members.filter((m) =>
     m.publicKey.toLowerCase().includes(search.toLowerCase()) ||

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -67,11 +67,10 @@ const UserProfile: React.FC = () => {
   const [message, setMessage] = useState<AppMessage | null>(null);
 
   useEffect(() => {
-    if (profileKey && publicKey) {
+    if (profileKey) {
       api
-        .get(`/api/user/${profileKey}`, {
-          headers: { 'X-Public-Key': publicKey.toBase58() },
-        })
+        .get(`/api/user/${profileKey}`,
+          publicKey ? { headers: { 'X-Public-Key': publicKey.toBase58() } } : undefined)
         .then((res) => setUser(res.data))
         .catch(() => setUser(null));
     }

--- a/frontend/src/pages/__tests__/Primos.test.tsx
+++ b/frontend/src/pages/__tests__/Primos.test.tsx
@@ -18,38 +18,33 @@ jest.mock('../services/helius', () => ({
   fetchCollectionNFTsForOwner: jest.fn(() => Promise.resolve([])),
 }));
 
-const renderPrimos = (connected: boolean) =>
+const renderPrimos = () =>
   render(
     <MemoryRouter>
-      <Primos connected={connected} />
+      <Primos />
     </MemoryRouter>
   );
 
 describe('Primos component', () => {
-  test('prompts login when not authenticated', () => {
-    renderPrimos(false);
-    expect(screen.getByText(/Please login to access Primos/i)).toBeTruthy();
-  });
-
-  test('shows members title when authenticated', () => {
-    renderPrimos(true);
+  test('shows members title', () => {
+    renderPrimos();
     expect(screen.getByText(/Primos/i)).toBeTruthy();
   });
 
   test('links each member to profile page', async () => {
-    renderPrimos(true);
+    renderPrimos();
     const link = await screen.findByRole('link');
     expect(link).toHaveAttribute('href', '/user/abcdef123456');
   });
 
   test('displays pesos pill', async () => {
-    renderPrimos(true);
+    renderPrimos();
     const pill = await screen.findByText(/Pesos: 2/i);
     expect(pill).toBeTruthy();
   });
 
   test('filters by domain name', async () => {
-    renderPrimos(true);
+    renderPrimos();
     const input = screen.getByPlaceholderText(/domain/i);
     screen.getByText(/cool.sol/); // ensure member rendered with domain
     expect(screen.getByText(/cool.sol/)).toBeTruthy();


### PR DESCRIPTION
## Summary
- allow profile data and DAO member list to be retrieved without login
- remove Primos page token gate and adapt tests
- show Primos link in sidebar for all users
- fetch profiles anonymously if no wallet connected

## Testing
- `npm test -- --watchAll=false` *(fails: cannot find modules, etc.)*
- `mvn -q test` *(fails: could not resolve maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687973417970832a8f618408c4afd86f