### PR TITLE
Fix gating for viewing Primos

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -228,9 +228,6 @@ const AppRoutes = () => {
     if ((!publicKey || (!isHolder && !betaRedeemed)) && location.pathname === '/stickers') {
       navigate('/', { replace: true });
     }
-    if ((!publicKey || (!isHolder && !betaRedeemed)) && location.pathname === '/primos') {
-      navigate('/', { replace: true });
-    }
     if (
       (!publicKey || publicKey.toBase58() !== ADMIN_WALLET) &&
       location.pathname === '/admin'
@@ -263,11 +260,11 @@ const AppRoutes = () => {
               <Route path="/labs"      element={<PrimoLabs />} />
               <Route path="/experiment1" element={<Experiment1 />} />
               <Route path="/stickers" element={<Stickers />} />
-              <Route path="/primos"    element={<Primos />} />
               <Route path="/profile"   element={<UserProfile />} />
               <Route path="/user/:publicKey" element={<UserProfile />} />
             </>
           )}
+          <Route path="/primos" element={<Primos />} />
 
           {publicKey?.toBase58() === ADMIN_WALLET && (
             <Route path="/admin" element={<Admin />} />

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -9,7 +9,6 @@ import { getPythSolPrice } from '../utils/pyth';
 import api from '../utils/api';
 import Avatar from '@mui/material/Avatar';
 import { useWallet } from '@solana/wallet-adapter-react';
-import { usePrimoHolder } from '../contexts/PrimoHolderContext';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
 
 interface Stats {
@@ -35,8 +34,7 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
   const [stats, setStats] = useState<Stats | null>(null);
   const [members, setMembers] = useState<DaoMember[]>([]);
   const wallet = useWallet();
-  const { isHolder } = usePrimoHolder();
-  const isConnected = connected ?? (wallet.connected && isHolder);
+  const isConnected = connected ?? wallet.connected;
 
   useEffect(() => {
     async function fetchStats() {
@@ -68,12 +66,9 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
   }, []);
 
   useEffect(() => {
-    if (!isConnected) return;
     const fetchMembers = async () => {
       try {
-        const res = await api.get<DaoMember[]>('/api/user/primos', {
-          headers: { 'X-Public-Key': wallet.publicKey?.toBase58() },
-        });
+        const res = await api.get<DaoMember[]>('/api/user/primos');
         const enriched = await Promise.all(
           res.data.slice(0, 5).map(async (m) => {
             let image = '';
@@ -93,7 +88,7 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
       }
     };
     fetchMembers();
-  }, [isConnected]);
+  }, []);
 
   return (
     <Box


### PR DESCRIPTION
## Summary
- allow `/primos` page to be visited without wallet holder status
- load DAO member avatars on the landing page for all visitors

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68799a14d79c832ab6437e5f155c505d