### PR TITLE
Fix daily points cron and add NFT holder rewards

### DIFF
--- a/backend/src/main/java/com/primos/model/User.java
+++ b/backend/src/main/java/com/primos/model/User.java
@@ -13,6 +13,7 @@ public class User extends PanacheMongoEntity {
     private int points = 0;
     private int pointsToday = 0;
     private String pointsDate = java.time.LocalDate.now().toString();
+    private int nftCount = 0;
     private int pesos = 1;
     private boolean primoHolder = false;
     private boolean daoMember = true;
@@ -83,6 +84,14 @@ public class User extends PanacheMongoEntity {
 
     public void setPointsDate(String pointsDate) {
         this.pointsDate = pointsDate;
+    }
+
+    public int getNftCount() {
+        return nftCount;
+    }
+
+    public void setNftCount(int nftCount) {
+        this.nftCount = nftCount;
     }
 
     public int getPesos() {

--- a/backend/src/main/java/com/primos/service/HolderPointsJob.java
+++ b/backend/src/main/java/com/primos/service/HolderPointsJob.java
@@ -1,0 +1,26 @@
+package com.primos.service;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import com.primos.model.User;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import io.quarkus.scheduler.Scheduled;
+
+@ApplicationScoped
+public class HolderPointsJob {
+    private static final Logger LOG = Logger.getLogger(HolderPointsJob.class.getName());
+
+    @Scheduled(cron = "0 0 10 * * ?")
+    void awardHolderPoints() {
+        List<User> users = User.listAll();
+        for (User user : users) {
+            int multiplier = 1 + user.getNftCount() / 5;
+            int add = 18 * multiplier;
+            user.setPoints(user.getPoints() + add);
+            user.persistOrUpdate();
+        }
+        LOG.info("Awarded holder points to all users");
+    }
+}

--- a/backend/src/main/java/com/primos/service/PointsResetJob.java
+++ b/backend/src/main/java/com/primos/service/PointsResetJob.java
@@ -19,9 +19,11 @@ public class PointsResetJob {
         String today = LocalDate.now().toString();
         List<User> users = User.listAll();
         for (User user : users) {
-            user.setPointsToday(0);
-            user.setPointsDate(today);
-            user.persistOrUpdate();
+            if (!today.equals(user.getPointsDate())) {
+                user.setPointsToday(0);
+                user.setPointsDate(today);
+                user.persistOrUpdate();
+            }
         }
         LOG.info("Reset daily points for all users");
     }

--- a/backend/src/test/java/com/primos/service/HolderPointsJobTest.java
+++ b/backend/src/test/java/com/primos/service/HolderPointsJobTest.java
@@ -1,0 +1,24 @@
+package com.primos.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.primos.model.User;
+import org.junit.jupiter.api.Test;
+
+public class HolderPointsJobTest {
+    @Test
+    public void testAwardHolderPoints() {
+        User user = new User();
+        user.setPublicKey("holder");
+        user.setNftCount(7); // multiplier 2
+        user.setPoints(10);
+        user.persist();
+
+        HolderPointsJob job = new HolderPointsJob();
+        job.awardHolderPoints();
+
+        User updated = User.find("publicKey", "holder").firstResult();
+        assertNotNull(updated);
+        assertEquals(10 + 36, updated.getPoints());
+    }
+}

--- a/backend/src/test/java/com/primos/service/PointsResetJobTest.java
+++ b/backend/src/test/java/com/primos/service/PointsResetJobTest.java
@@ -11,6 +11,7 @@ public class PointsResetJobTest {
         User user = new User();
         user.setPublicKey("test");
         user.setPointsToday(3);
+        user.setPointsDate("2000-01-01");
         user.persist();
 
         PointsResetJob job = new PointsResetJob();
@@ -19,5 +20,6 @@ public class PointsResetJobTest {
         User updated = User.find("publicKey", "test").firstResult();
         assertNotNull(updated);
         assertEquals(0, updated.getPointsToday());
+        assertEquals(java.time.LocalDate.now().toString(), updated.getPointsDate());
     }
 }


### PR DESCRIPTION
## Summary
- ensure daily points reset only if not already updated
- add NFT count to `User`
- create `HolderPointsJob` to grant holder rewards
- test cron behaviors for both reset and holder points

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0af7e778832aa5884868cf1156e7