### PR TITLE
Update NFT counts from blockchain

### DIFF
--- a/backend/src/main/java/com/primos/service/HeliusService.java
+++ b/backend/src/main/java/com/primos/service/HeliusService.java
@@ -1,0 +1,83 @@
+package com.primos.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+@ApplicationScoped
+public class HeliusService {
+    private static final String API_KEY = System.getenv("REACT_APP_HELIUS_API_KEY");
+    private static final String COLLECTION = System.getenv().getOrDefault("REACT_APP_PRIMOS_COLLECTION", "primos");
+    private static final HttpClient CLIENT = createClient();
+
+    private static HttpClient createClient() {
+        String proxy = System.getenv("https_proxy");
+        if (proxy == null || proxy.isEmpty()) {
+            proxy = System.getenv("HTTPS_PROXY");
+        }
+        if (proxy != null && !proxy.isEmpty()) {
+            try {
+                URI uri = URI.create(proxy);
+                return HttpClient.newBuilder()
+                        .proxy(ProxySelector.of(new InetSocketAddress(uri.getHost(), uri.getPort())))
+                        .build();
+            } catch (Exception ignored) {}
+        }
+        return HttpClient.newHttpClient();
+    }
+
+    /**
+     * Retrieves the number of NFTs from the Primos collection owned by the given wallet.
+     *
+     * @param wallet the wallet address to query
+     * @return the count of NFTs or 0 on failure
+     */
+    public int getPrimoCount(String wallet) {
+        if (API_KEY == null || API_KEY.isEmpty() || wallet == null || wallet.isEmpty()) {
+            return 0;
+        }
+        try {
+            int page = 1;
+            int limit = 100;
+            int total = 0;
+            while (true) {
+                String body = String.format(
+                        "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"searchAssets\",\"params\":{\"ownerAddress\":\"%s\",\"grouping\":[\"collection\",\"%s\"],\"tokenType\":\"regularNft\",\"page\":%d,\"limit\":%d}}",
+                        wallet, COLLECTION, page, limit);
+                HttpRequest req = HttpRequest.newBuilder()
+                        .uri(URI.create("https://mainnet.helius-rpc.com/?api-key=" + API_KEY))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body))
+                        .build();
+                HttpResponse<String> resp = CLIENT.send(req, HttpResponse.BodyHandlers.ofString());
+                if (resp.statusCode() != 200) {
+                    break;
+                }
+                try (JsonReader reader = Json.createReader(new StringReader(resp.body()))) {
+                    JsonObject obj = reader.readObject();
+                    JsonObject result = obj.getJsonObject("result");
+                    if (result == null) break;
+                    JsonArray items = result.getJsonArray("items");
+                    if (items == null) break;
+                    total += items.size();
+                    if (items.size() < limit) {
+                        break;
+                    }
+                    page++;
+                }
+            }
+            return total;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}

--- a/backend/src/main/java/com/primos/service/HolderPointsJob.java
+++ b/backend/src/main/java/com/primos/service/HolderPointsJob.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import com.primos.model.User;
+import jakarta.inject.Inject;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import io.quarkus.scheduler.Scheduled;
@@ -12,11 +13,18 @@ import io.quarkus.scheduler.Scheduled;
 public class HolderPointsJob {
     private static final Logger LOG = Logger.getLogger(HolderPointsJob.class.getName());
 
+    @Inject
+    HeliusService heliusService;
+
     @Scheduled(cron = "0 0 10 * * ?")
     void awardHolderPoints() {
         List<User> users = User.listAll();
         for (User user : users) {
-            int multiplier = 1 + user.getNftCount() / 5;
+            int count = heliusService.getPrimoCount(user.getPublicKey());
+            user.setNftCount(count);
+            user.setPrimoHolder(count > 0);
+            user.setDaoMember(count > 0);
+            int multiplier = 1 + count / 5;
             int add = 18 * multiplier;
             user.setPoints(user.getPoints() + add);
             user.persistOrUpdate();

--- a/backend/src/main/java/com/primos/service/LoginService.java
+++ b/backend/src/main/java/com/primos/service/LoginService.java
@@ -7,6 +7,8 @@ import com.primos.model.User;
 import com.primos.resource.AdminResource;
 import com.primos.resource.LoginRequest;
 
+import jakarta.inject.Inject;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
@@ -16,6 +18,9 @@ public class LoginService {
     private static final Logger LOGGER = Logger.getLogger(LoginService.class.getName());
     private static final String PUBLIC_KEY_FIELD = "publicKey";
     private static final String ADMIN_WALLET = AdminResource.ADMIN_WALLET;
+
+    @Inject
+    HeliusService heliusService;
 
     public User login(LoginRequest req) {
         validateLoginRequest(req);
@@ -63,6 +68,12 @@ public class LoginService {
             }
         }
         user.persistOrUpdate();
+
+        // Update NFT count from the blockchain on each login
+        int count = heliusService.getPrimoCount(user.getPublicKey());
+        user.setNftCount(count);
+        updateHolderStatus(user, count > 0);
+
         if (LOGGER.isLoggable(java.util.logging.Level.INFO)) {
             if (user.isPrimoHolder()) {
                 LOGGER.info(String.format("[LoginService] Primo holder login for publicKey: %s", req.publicKey));


### PR DESCRIPTION
## Summary
- add `HeliusService` to query Helius for user NFT totals
- update `LoginService` to refresh nftCount on login
- update `HolderPointsJob` to pull counts from Helius before awarding points

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687b0e494898832ab775b7a768842b9c