### PR TITLE
Add Trenches experiment

### DIFF
--- a/backend/src/main/java/com/primos/model/TrenchContract.java
+++ b/backend/src/main/java/com/primos/model/TrenchContract.java
@@ -1,0 +1,26 @@
+package com.primos.model;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+
+@MongoEntity(collection = "trenches")
+public class TrenchContract extends PanacheMongoEntity {
+    private String contract;
+    private int count;
+
+    public String getContract() {
+        return contract;
+    }
+
+    public void setContract(String contract) {
+        this.contract = contract;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/backend/src/main/java/com/primos/model/TrenchUser.java
+++ b/backend/src/main/java/com/primos/model/TrenchUser.java
@@ -1,0 +1,26 @@
+package com.primos.model;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+
+@MongoEntity(collection = "trenchUsers")
+public class TrenchUser extends PanacheMongoEntity {
+    private String publicKey;
+    private int count;
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/backend/src/main/java/com/primos/resource/TrenchResource.java
+++ b/backend/src/main/java/com/primos/resource/TrenchResource.java
@@ -1,0 +1,62 @@
+package com.primos.resource;
+
+import com.primos.model.TrenchContract;
+import com.primos.model.TrenchUser;
+import com.primos.model.User;
+import com.primos.service.TrenchService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Path("/api/trench")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class TrenchResource {
+    @Inject
+    TrenchService service;
+
+    public static class TrenchUserInfo {
+        public String publicKey;
+        public String pfp;
+        public int count;
+    }
+
+    public static class TrenchData {
+        public List<TrenchContract> contracts;
+        public List<TrenchUserInfo> users;
+    }
+
+    @POST
+    public void add(@HeaderParam("X-Public-Key") String publicKey, Map<String, String> req) {
+        if (publicKey == null || req == null || !req.containsKey("contract")) {
+            throw new BadRequestException();
+        }
+        service.add(publicKey, req.get("contract"));
+    }
+
+    @GET
+    public TrenchData get() {
+        TrenchData data = new TrenchData();
+        data.contracts = service.getContracts();
+        List<TrenchUser> users = service.getUsers();
+        data.users = users.stream().map(u -> {
+            TrenchUserInfo info = new TrenchUserInfo();
+            info.publicKey = u.getPublicKey();
+            info.count = u.getCount();
+            User user = User.find("publicKey", u.getPublicKey()).firstResult();
+            info.pfp = user != null ? user.getPfp() : "";
+            return info;
+        }).collect(Collectors.toList());
+        return data;
+    }
+}

--- a/backend/src/main/java/com/primos/service/TrenchService.java
+++ b/backend/src/main/java/com/primos/service/TrenchService.java
@@ -1,0 +1,42 @@
+package com.primos.service;
+
+import com.primos.model.TrenchContract;
+import com.primos.model.TrenchUser;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+
+@ApplicationScoped
+public class TrenchService {
+    public void add(String publicKey, String contract) {
+        TrenchContract tc = TrenchContract.find("contract", contract).firstResult();
+        if (tc == null) {
+            tc = new TrenchContract();
+            tc.setContract(contract);
+            tc.setCount(1);
+            tc.persist();
+        } else {
+            tc.setCount(tc.getCount() + 1);
+            tc.persistOrUpdate();
+        }
+
+        TrenchUser tu = TrenchUser.find("publicKey", publicKey).firstResult();
+        if (tu == null) {
+            tu = new TrenchUser();
+            tu.setPublicKey(publicKey);
+            tu.setCount(1);
+            tu.persist();
+        } else {
+            tu.setCount(tu.getCount() + 1);
+            tu.persistOrUpdate();
+        }
+    }
+
+    public List<TrenchContract> getContracts() {
+        return TrenchContract.listAll();
+    }
+
+    public List<TrenchUser> getUsers() {
+        return TrenchUser.listAll();
+    }
+}

--- a/backend/src/test/java/com/primos/resource/TrenchResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/TrenchResourceTest.java
@@ -1,0 +1,20 @@
+package com.primos.resource;
+
+import com.primos.model.TrenchContract;
+import com.primos.model.TrenchUser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TrenchResourceTest {
+    @Test
+    public void testAddAndGet() {
+        TrenchResource res = new TrenchResource();
+        res.add("w1", java.util.Map.of("contract", "ca1"));
+        TrenchResource.TrenchData data = res.get();
+        assertEquals(1, data.contracts.size());
+        assertEquals("ca1", data.contracts.get(0).getContract());
+        assertEquals(1, data.users.size());
+        assertEquals("w1", data.users.get(0).publicKey);
+    }
+}

--- a/backend/src/test/java/com/primos/service/TrenchServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TrenchServiceTest.java
@@ -1,0 +1,25 @@
+package com.primos.service;
+
+import com.primos.model.TrenchContract;
+import com.primos.model.TrenchUser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TrenchServiceTest {
+    @Test
+    public void testAddIncrementsCounts() {
+        TrenchService svc = new TrenchService();
+        svc.add("u1", "ca1");
+        svc.add("u1", "ca1");
+        svc.add("u2", "ca1");
+
+        TrenchContract tc = TrenchContract.find("contract", "ca1").firstResult();
+        assertEquals(3, tc.getCount());
+
+        TrenchUser u1 = TrenchUser.find("publicKey", "u1").firstResult();
+        assertEquals(2, u1.getCount());
+        TrenchUser u2 = TrenchUser.find("publicKey", "u2").firstResult();
+        assertEquals(1, u2.getCount());
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import PrimoLabs from './pages/PrimoLabs';
 import Primos from './pages/Primos';
 import Experiment1 from './pages/Experiment1';
 import Stickers from './pages/Stickers';
+import Trenches from './pages/Trenches';
 import Docs from './pages/Docs';
 import Admin from './pages/Admin';
 import BetaRedeem from './components/BetaRedeem';
@@ -228,6 +229,9 @@ const AppRoutes = () => {
     if ((!publicKey || (!isHolder && !betaRedeemed)) && location.pathname === '/stickers') {
       navigate('/', { replace: true });
     }
+    if ((!publicKey || (!isHolder && !betaRedeemed)) && location.pathname === '/trenches') {
+      navigate('/', { replace: true });
+    }
     if (
       (!publicKey || publicKey.toBase58() !== ADMIN_WALLET) &&
       location.pathname === '/admin'
@@ -260,6 +264,7 @@ const AppRoutes = () => {
               <Route path="/labs"      element={<PrimoLabs />} />
               <Route path="/experiment1" element={<Experiment1 />} />
               <Route path="/stickers" element={<Stickers />} />
+              <Route path="/trenches" element={<Trenches />} />
               <Route path="/profile"   element={<UserProfile />} />
               <Route path="/user/:publicKey" element={<UserProfile />} />
             </>

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -182,4 +182,8 @@
   "experiment2_desc": "Order stickers of your Primo NFTs with QR codes linking back to the marketplace and your socials. 5% of the cost goes to the DAO.",
   "order_sticker": "Order Sticker",
   "stickers_order_thanks": "Sticker ordering coming soon!"
+  ,"experiment3_title": "Trenches"
+  ,"experiment3_desc": "Enter contract addresses to grow the trenches. Bubbles expand as more users join."
+  ,"enter_contract": "Enter contract address"
+  ,"add_contract": "Add Contract"
 }

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -182,4 +182,8 @@
   "experiment2_desc": "Ordena calcomanías de tus Primos NFTs con códigos QR que enlazan al marketplace y a tus redes. El 5% del costo apoya al DAO.",
   "order_sticker": "Pedir calcomanía",
   "stickers_order_thanks": "¡Pronto podrás completar tu pedido!"
+  ,"experiment3_title": "Trincheras"
+  ,"experiment3_desc": "Ingresa direcciones de contrato para hacer crecer las trincheras. Las burbujas aumentan al unirse más usuarios."
+  ,"enter_contract": "Ingresa dirección de contrato"
+  ,"add_contract": "Agregar Contrato"
 }

--- a/frontend/src/pages/PrimoLabs.tsx
+++ b/frontend/src/pages/PrimoLabs.tsx
@@ -8,6 +8,7 @@ import Card from '@mui/material/Card';
 import LinearProgress from '@mui/material/LinearProgress';
 import ThreeDRotationIcon from '@mui/icons-material/ThreeDRotation';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import MilitaryTechIcon from '@mui/icons-material/MilitaryTech';
 import { Link } from 'react-router-dom';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
 import api from '../utils/api';
@@ -80,6 +81,14 @@ const PrimoLabs: React.FC<{ connected?: boolean }> = ({ connected }) => {
             <LocalOfferIcon sx={{ fontSize: 40 }} />
             <Typography variant="h6" sx={{ mt: 1 }}>
               {t('experiment2_title')}
+            </Typography>
+          </Box>
+        </Card>
+        <Card className="lab-card" component={Link} to="/trenches" sx={{ textDecoration: 'none' }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <MilitaryTechIcon sx={{ fontSize: 40 }} />
+            <Typography variant="h6" sx={{ mt: 1 }}>
+              {t('experiment3_title')}
             </Typography>
           </Box>
         </Card>

--- a/frontend/src/pages/Trenches.css
+++ b/frontend/src/pages/Trenches.css
@@ -1,0 +1,26 @@
+.experiment-container {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.bubble-map {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.bubble {
+  background: #1976d2;
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+}
+
+.user-bubble {
+  border: 2px solid #1976d2;
+}

--- a/frontend/src/pages/Trenches.tsx
+++ b/frontend/src/pages/Trenches.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Avatar from '@mui/material/Avatar';
+import { useWallet } from '@solana/wallet-adapter-react';
+import { useTranslation } from 'react-i18next';
+import api from '../utils/api';
+import './Trenches.css';
+
+interface TrenchContract {
+  contract: string;
+  count: number;
+}
+
+interface TrenchUser {
+  publicKey: string;
+  pfp: string;
+  count: number;
+}
+
+interface TrenchData {
+  contracts: TrenchContract[];
+  users: TrenchUser[];
+}
+
+const Trenches: React.FC = () => {
+  const { publicKey } = useWallet();
+  const { t } = useTranslation();
+  const [input, setInput] = useState('');
+  const [data, setData] = useState<TrenchData>({ contracts: [], users: [] });
+
+  const load = async () => {
+    const res = await api.get<TrenchData>('/api/trench');
+    setData(res.data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleAdd = async () => {
+    if (!input) return;
+    await api.post('/api/trench', { contract: input }, {
+      headers: { 'X-Public-Key': publicKey?.toBase58() },
+    });
+    setInput('');
+    load();
+  };
+
+  return (
+    <Box className="experiment-container">
+      <Typography variant="h4" sx={{ mb: 2 }}>
+        {t('experiment3_title')}
+      </Typography>
+      <Typography variant="body1" sx={{ mb: 2 }}>
+        {t('experiment3_desc')}
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center', mb: 2 }}>
+        <TextField
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={t('enter_contract')}
+          size="small"
+        />
+        <Button variant="contained" onClick={handleAdd} disabled={!input}>
+          {t('add_contract')}
+        </Button>
+      </Box>
+      <Box className="bubble-map">
+        {data.contracts.map((c) => (
+          <Box
+            key={c.contract}
+            className="bubble"
+            sx={{ width: 40 + c.count * 10, height: 40 + c.count * 10 }}
+          >
+            {c.contract}
+          </Box>
+        ))}
+      </Box>
+      <Box className="bubble-map" sx={{ mt: 4 }}>
+        {data.users.map((u) => (
+          <Avatar
+            key={u.publicKey}
+            src={u.pfp || undefined}
+            className="user-bubble"
+            sx={{ width: 30 + u.count * 5, height: 30 + u.count * 5 }}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default Trenches;

--- a/frontend/src/pages/__tests__/PrimoLabs.test.tsx
+++ b/frontend/src/pages/__tests__/PrimoLabs.test.tsx
@@ -22,6 +22,7 @@ describe('PrimoLabs', () => {
     expect(screen.getByText(/Primo Labs/i)).toBeTruthy();
     expect(screen.getByText(/Experiment #1/i)).toBeTruthy();
     expect(screen.getByText(/Experiment #2/i)).toBeTruthy();
+    expect(screen.getByText(/Trenches/i)).toBeTruthy();
     expect(screen.queryByText(/Meme Wars/i)).toBeNull();
     expect(screen.queryByText(/Eliza AI Trading Bot/i)).toBeNull();
   });

--- a/frontend/src/pages/__tests__/Trenches.test.tsx
+++ b/frontend/src/pages/__tests__/Trenches.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../i18n';
+import Trenches from '../Trenches';
+
+jest.mock('../utils/api', () => ({
+  get: jest.fn(() => Promise.resolve({ data: { contracts: [], users: [] } })),
+  post: jest.fn(() => Promise.resolve()),
+}));
+
+describe('Trenches page', () => {
+  test('renders add button disabled', async () => {
+    render(
+      <MemoryRouter>
+        <I18nextProvider i18n={i18n}>
+          <Trenches />
+        </I18nextProvider>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Trenches/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Add Contract/i })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- create `TrenchContract` and `TrenchUser` models
- create `TrenchService` and REST resource
- implement new React page `Trenches`
- hook Trenches into navigation and translations
- add tests for PrimoLabs and Trenches

## Testing
- `npm test -- --watchAll=false` *(fails: Test Suites: 18 failed, 13 passed)*
- `mvn test` *(fails to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687b1d0a9168832aa8035440c32faab0