### PR TITLE
Add rate limit to trench submissions and enrich map pfps

### DIFF
--- a/backend/src/main/java/com/primos/model/TrenchUser.java
+++ b/backend/src/main/java/com/primos/model/TrenchUser.java
@@ -7,6 +7,7 @@ import io.quarkus.mongodb.panache.common.MongoEntity;
 public class TrenchUser extends PanacheMongoEntity {
     private String publicKey;
     private int count;
+    private long lastSubmittedAt;
 
     public String getPublicKey() {
         return publicKey;
@@ -22,5 +23,13 @@ public class TrenchUser extends PanacheMongoEntity {
 
     public void setCount(int count) {
         this.count = count;
+    }
+
+    public long getLastSubmittedAt() {
+        return lastSubmittedAt;
+    }
+
+    public void setLastSubmittedAt(long lastSubmittedAt) {
+        this.lastSubmittedAt = lastSubmittedAt;
     }
 }

--- a/backend/src/test/java/com/primos/service/TrenchServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TrenchServiceTest.java
@@ -11,14 +11,14 @@ public class TrenchServiceTest {
     public void testAddIncrementsCounts() {
         TrenchService svc = new TrenchService();
         svc.add("u1", "ca1");
-        svc.add("u1", "ca1");
+        assertThrows(jakarta.ws.rs.BadRequestException.class, () -> svc.add("u1", "ca1"));
         svc.add("u2", "ca1");
 
         TrenchContract tc = TrenchContract.find("contract", "ca1").firstResult();
-        assertEquals(3, tc.getCount());
+        assertEquals(2, tc.getCount());
 
         TrenchUser u1 = TrenchUser.find("publicKey", "u1").firstResult();
-        assertEquals(2, u1.getCount());
+        assertEquals(1, u1.getCount());
         TrenchUser u2 = TrenchUser.find("publicKey", "u2").firstResult();
         assertEquals(1, u2.getCount());
     }

--- a/frontend/src/pages/__tests__/Trenches.test.tsx
+++ b/frontend/src/pages/__tests__/Trenches.test.tsx
@@ -10,6 +10,11 @@ jest.mock('../utils/api', () => ({
   post: jest.fn(() => Promise.resolve()),
 }));
 
+jest.mock('../utils/helius', () => ({
+  getNFTByTokenAddress: jest.fn(() => Promise.resolve(null)),
+  fetchCollectionNFTsForOwner: jest.fn(() => Promise.resolve([])),
+}));
+
 describe('Trenches page', () => {
   test('renders add button disabled', async () => {
     render(


### PR DESCRIPTION
## Summary
- enrich trench map bubbles with actual NFT images
- prevent trench submissions from being spammed by adding a 1 minute cooldown per user
- update trench service tests for new behavior
- include helius mocks in trench page test

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm test -- --watchAll=false` *(fails: many modules cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_687b281909f4832aa3e5e829f5e255ed