### PR TITLE
Remove Experiment numbering

### DIFF
--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -133,7 +133,7 @@
   "make_an_offer": "Make an Offer",
   "list": "List",
   "go": "Go",
-  "experiment1_title": "Experiment #1",
+  "experiment1_title": "Primo 3D",
   "experiment1_desc": "Upload your Primo NFT image and generate a 3D model using Meshy.ai.",
   "experiment1_render": "Render 3D",
   "redeem_beta": "Redeem Beta Code",
@@ -178,7 +178,7 @@
   "has_3d": "3D available",
   "tx_success": "Transaction sent!",
   "tx_failed": "Transaction failed",
-  "experiment2_title": "Experiment #2",
+  "experiment2_title": "Stickers",
   "experiment2_desc": "Order stickers of your Primo NFTs with QR codes linking back to the marketplace and your socials. 5% of the cost goes to the DAO.",
   "order_sticker": "Order Sticker",
   "stickers_order_thanks": "Sticker ordering coming soon!"

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -133,7 +133,7 @@
   "make_an_offer": "Hacer una oferta",
   "list": "Listar",
   "go": "Ir",
-  "experiment1_title": "Experimento #1",
+  "experiment1_title": "Primo 3D",
   "experiment1_desc": "Sube la imagen de tu Primo NFT y genera un modelo 3D usando Meshy.ai.",
   "experiment1_render": "Renderizar 3D",
   "redeem_beta": "Canjear código Beta",
@@ -178,7 +178,7 @@
   "has_3d": "3D disponible",
   "tx_success": "¡Transacción enviada!",
   "tx_failed": "Transacción fallida",
-  "experiment2_title": "Experimento #2",
+  "experiment2_title": "Calcomanías",
   "experiment2_desc": "Ordena calcomanías de tus Primos NFTs con códigos QR que enlazan al marketplace y a tus redes. El 5% del costo apoya al DAO.",
   "order_sticker": "Pedir calcomanía",
   "stickers_order_thanks": "¡Pronto podrás completar tu pedido!"

--- a/frontend/src/pages/PrimoLabs.tsx
+++ b/frontend/src/pages/PrimoLabs.tsx
@@ -9,6 +9,7 @@ import LinearProgress from '@mui/material/LinearProgress';
 import ThreeDRotationIcon from '@mui/icons-material/ThreeDRotation';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import MilitaryTechIcon from '@mui/icons-material/MilitaryTech';
+import Tooltip from '@mui/material/Tooltip';
 import { Link } from 'react-router-dom';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
 import api from '../utils/api';
@@ -68,30 +69,27 @@ const PrimoLabs: React.FC<{ connected?: boolean }> = ({ connected }) => {
   return (
     <Box className="labs-container">
       <Box className="labs-grid">
-        <Card className="lab-card" component={Link} to="/experiment1" sx={{ textDecoration: 'none' }}>
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <ThreeDRotationIcon sx={{ fontSize: 40 }} />
-            <Typography variant="h6" sx={{ mt: 1 }}>
-              {t('experiment1_title')}
-            </Typography>
-          </Box>
-        </Card>
-        <Card className="lab-card" component={Link} to="/stickers" sx={{ textDecoration: 'none' }}>
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <LocalOfferIcon sx={{ fontSize: 40 }} />
-            <Typography variant="h6" sx={{ mt: 1 }}>
-              {t('experiment2_title')}
-            </Typography>
-          </Box>
-        </Card>
-        <Card className="lab-card" component={Link} to="/trenches" sx={{ textDecoration: 'none' }}>
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <MilitaryTechIcon sx={{ fontSize: 40 }} />
-            <Typography variant="h6" sx={{ mt: 1 }}>
-              {t('experiment3_title')}
-            </Typography>
-          </Box>
-        </Card>
+        <Tooltip title={t('experiment1_desc')} arrow>
+          <Card className="lab-card" component={Link} to="/experiment1" sx={{ textDecoration: 'none' }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+              <ThreeDRotationIcon sx={{ fontSize: 40 }} />
+            </Box>
+          </Card>
+        </Tooltip>
+        <Tooltip title={t('experiment2_desc')} arrow>
+          <Card className="lab-card" component={Link} to="/stickers" sx={{ textDecoration: 'none' }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+              <LocalOfferIcon sx={{ fontSize: 40 }} />
+            </Box>
+          </Card>
+        </Tooltip>
+        <Tooltip title={t('experiment3_desc')} arrow>
+          <Card className="lab-card" component={Link} to="/trenches" sx={{ textDecoration: 'none' }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+              <MilitaryTechIcon sx={{ fontSize: 40 }} />
+            </Box>
+          </Card>
+        </Tooltip>
         <Card className="lab-card">
           <Typography variant="h6" sx={{ mt: 1 }}>
             {t('coming_soon')}

--- a/frontend/src/pages/__tests__/Experiment1.test.tsx
+++ b/frontend/src/pages/__tests__/Experiment1.test.tsx
@@ -22,7 +22,7 @@ describe('Experiment1 page', () => {
         </I18nextProvider>
       </MemoryRouter>
     );
-    expect(screen.getByText(/Experiment #1/i)).toBeTruthy();
+    expect(screen.getByText(/Primo 3D/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /Render 3D/i })).toBeDisabled();
   });
 });

--- a/frontend/src/pages/__tests__/PrimoLabs.test.tsx
+++ b/frontend/src/pages/__tests__/PrimoLabs.test.tsx
@@ -20,8 +20,6 @@ describe('PrimoLabs', () => {
   test('shows labs content when authenticated', () => {
     renderLabs(true);
     expect(screen.getByText(/Primo Labs/i)).toBeTruthy();
-    expect(screen.getByText(/Experiment #1/i)).toBeTruthy();
-    expect(screen.getByText(/Experiment #2/i)).toBeTruthy();
     expect(screen.getByText(/Trenches/i)).toBeTruthy();
     expect(screen.queryByText(/Meme Wars/i)).toBeNull();
     expect(screen.queryByText(/Eliza AI Trading Bot/i)).toBeNull();

--- a/frontend/src/pages/__tests__/Stickers.test.tsx
+++ b/frontend/src/pages/__tests__/Stickers.test.tsx
@@ -18,7 +18,7 @@ describe('Stickers page', () => {
         </I18nextProvider>
       </MemoryRouter>
     );
-    expect(screen.getByText(/Experiment #2/i)).toBeTruthy();
+    expect(screen.getByText(/Stickers/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /Order Sticker/i })).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary
- remove titles from PrimoLabs cards and show experiment description in tooltip
- rename experiment titles in i18n files
- update tests for new titles

## Testing
- `npm test` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9f5b7e6c832abef5901fb520787d