### PR TITLE
Implement user-specific trench view

### DIFF
--- a/backend/src/main/java/com/primos/model/TrenchUser.java
+++ b/backend/src/main/java/com/primos/model/TrenchUser.java
@@ -8,6 +8,7 @@ public class TrenchUser extends PanacheMongoEntity {
     private String publicKey;
     private int count;
     private long lastSubmittedAt;
+    private java.util.List<String> contracts;
 
     public String getPublicKey() {
         return publicKey;
@@ -31,5 +32,13 @@ public class TrenchUser extends PanacheMongoEntity {
 
     public void setLastSubmittedAt(long lastSubmittedAt) {
         this.lastSubmittedAt = lastSubmittedAt;
+    }
+
+    public java.util.List<String> getContracts() {
+        return contracts;
+    }
+
+    public void setContracts(java.util.List<String> contracts) {
+        this.contracts = contracts;
     }
 }

--- a/backend/src/main/java/com/primos/resource/TrenchResource.java
+++ b/backend/src/main/java/com/primos/resource/TrenchResource.java
@@ -29,6 +29,7 @@ public class TrenchResource {
         public String publicKey;
         public String pfp;
         public int count;
+        public java.util.List<String> contracts;
     }
 
     public static class TrenchData {
@@ -55,6 +56,7 @@ public class TrenchResource {
             info.count = u.getCount();
             User user = User.find("publicKey", u.getPublicKey()).firstResult();
             info.pfp = user != null ? user.getPfp() : "";
+            info.contracts = u.getContracts();
             return info;
         }).collect(Collectors.toList());
         return data;

--- a/backend/src/main/java/com/primos/service/TrenchService.java
+++ b/backend/src/main/java/com/primos/service/TrenchService.java
@@ -5,6 +5,7 @@ import com.primos.model.TrenchUser;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.List;
+import java.util.ArrayList;
 import jakarta.ws.rs.BadRequestException;
 
 @ApplicationScoped
@@ -28,6 +29,9 @@ public class TrenchService {
             tu = new TrenchUser();
             tu.setPublicKey(publicKey);
             tu.setCount(1);
+            java.util.List<String> list = new ArrayList<>();
+            list.add(contract);
+            tu.setContracts(list);
             tu.setLastSubmittedAt(now);
             tu.persist();
         } else {
@@ -36,6 +40,12 @@ public class TrenchService {
                 throw new BadRequestException();
             }
             tu.setCount(tu.getCount() + 1);
+            java.util.List<String> list = tu.getContracts();
+            if (list == null) list = new ArrayList<>();
+            if (!list.contains(contract)) {
+                list.add(contract);
+            }
+            tu.setContracts(list);
             tu.setLastSubmittedAt(now);
             tu.persistOrUpdate();
         }

--- a/backend/src/test/java/com/primos/resource/TrenchResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/TrenchResourceTest.java
@@ -16,5 +16,6 @@ public class TrenchResourceTest {
         assertEquals("ca1", data.contracts.get(0).getContract());
         assertEquals(1, data.users.size());
         assertEquals("w1", data.users.get(0).publicKey);
+        assertTrue(data.users.get(0).contracts.contains("ca1"));
     }
 }

--- a/backend/src/test/java/com/primos/service/TrenchServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TrenchServiceTest.java
@@ -19,6 +19,7 @@ public class TrenchServiceTest {
 
         TrenchUser u1 = TrenchUser.find("publicKey", "u1").firstResult();
         assertEquals(1, u1.getCount());
+        assertTrue(u1.getContracts().contains("ca1"));
         TrenchUser u2 = TrenchUser.find("publicKey", "u2").firstResult();
         assertEquals(1, u2.getCount());
     }

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -186,4 +186,6 @@
   ,"experiment3_desc": "Enter contract addresses to grow the trenches. Bubbles expand as more users join."
   ,"enter_contract": "Enter contract address"
   ,"add_contract": "Add Contract"
+  ,"my_contracts": "My Contracts"
+  ,"all_users": "All Users"
 }

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -186,4 +186,6 @@
   ,"experiment3_desc": "Ingresa direcciones de contrato para hacer crecer las trincheras. Las burbujas aumentan al unirse más usuarios."
   ,"enter_contract": "Ingresa dirección de contrato"
   ,"add_contract": "Agregar Contrato"
+  ,"my_contracts": "Mis Contratos"
+  ,"all_users": "Todos los Usuarios"
 }

--- a/frontend/src/pages/Trenches.tsx
+++ b/frontend/src/pages/Trenches.tsx
@@ -21,6 +21,7 @@ interface TrenchUser {
   publicKey: string;
   pfp: string;
   count: number;
+  contracts: string[];
 }
 
 interface TrenchData {
@@ -33,6 +34,8 @@ const Trenches: React.FC = () => {
   const { t } = useTranslation();
   const [input, setInput] = useState('');
   const [data, setData] = useState<TrenchData>({ contracts: [], users: [] });
+  const [viewAll, setViewAll] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<TrenchUser | null>(null);
 
   const load = async () => {
     const res = await api.get<TrenchData>('/api/trench');
@@ -87,41 +90,86 @@ const Trenches: React.FC = () => {
           {t('add_contract')}
         </Button>
       </Box>
-      <Box className="bubble-map">
-        {data.contracts.map((c) => {
-          const short =
-            c.contract.length > 7
-              ? `${c.contract.slice(0, 3)}...${c.contract.slice(-4)}`
-              : c.contract;
-          return (
-            <Box
-              key={c.contract}
-              className="bubble"
-              sx={{ width: 40 + c.count * 10, height: 40 + c.count * 10 }}
-            >
-              {short}
+      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center', mb: 2 }}>
+        <Button
+          variant={!viewAll ? 'contained' : 'outlined'}
+          onClick={() => setViewAll(false)}
+        >
+          {t('my_contracts')}
+        </Button>
+        <Button
+          variant={viewAll ? 'contained' : 'outlined'}
+          onClick={() => {
+            setViewAll(true);
+            setSelectedUser(null);
+          }}
+        >
+          {t('all_users')}
+        </Button>
+      </Box>
+      {!viewAll && (
+        <Box className="bubble-map">
+          {(data.users.find((u) => u.publicKey === publicKey?.toBase58())?.
+            contracts || [])
+            .map((c) => {
+              const count =
+                data.contracts.find((cc) => cc.contract === c)?.count || 1;
+              const short =
+                c.length > 7 ? `${c.slice(0, 3)}...${c.slice(-4)}` : c;
+              return (
+                <Box
+                  key={c}
+                  className="bubble"
+                  sx={{ width: 40 + count * 10, height: 40 + count * 10 }}
+                >
+                  {short}
+                </Box>
+              );
+            })}
+        </Box>
+      )}
+      {viewAll && (
+        <>
+          <Box className="bubble-map">
+            {data.users.map((u) => {
+              const short =
+                u.publicKey.length > 7
+                  ? `${u.publicKey.slice(0, 3)}...${u.publicKey.slice(-4)}`
+                  : u.publicKey;
+              return (
+                <Avatar
+                  key={u.publicKey}
+                  src={u.pfp || undefined}
+                  alt={short}
+                  title={short}
+                  className="user-bubble"
+                  sx={{ width: 30 + u.count * 5, height: 30 + u.count * 5 }}
+                  onClick={() => setSelectedUser(u)}
+                />
+              );
+            })}
+          </Box>
+          {selectedUser && (
+            <Box className="bubble-map" sx={{ mt: 2 }}>
+              {selectedUser.contracts.map((c) => {
+                const count =
+                  data.contracts.find((cc) => cc.contract === c)?.count || 1;
+                const short =
+                  c.length > 7 ? `${c.slice(0, 3)}...${c.slice(-4)}` : c;
+                return (
+                  <Box
+                    key={c}
+                    className="bubble"
+                    sx={{ width: 40 + count * 10, height: 40 + count * 10 }}
+                  >
+                    {short}
+                  </Box>
+                );
+              })}
             </Box>
-          );
-        })}
-      </Box>
-      <Box className="bubble-map" sx={{ mt: 4 }}>
-        {data.users.map((u) => {
-          const short =
-            u.publicKey.length > 7
-              ? `${u.publicKey.slice(0, 3)}...${u.publicKey.slice(-4)}`
-              : u.publicKey;
-          return (
-            <Avatar
-              key={u.publicKey}
-              src={u.pfp || undefined}
-              alt={short}
-              title={short}
-              className="user-bubble"
-              sx={{ width: 30 + u.count * 5, height: 30 + u.count * 5 }}
-            />
-          );
-        })}
-      </Box>
+          )}
+        </>
+      )}
     </Box>
   );
 };

--- a/frontend/src/pages/__tests__/Trenches.test.tsx
+++ b/frontend/src/pages/__tests__/Trenches.test.tsx
@@ -6,7 +6,14 @@ import i18n from '../../i18n';
 import Trenches from '../Trenches';
 
 jest.mock('../utils/api', () => ({
-  get: jest.fn(() => Promise.resolve({ data: { contracts: [], users: [] } })),
+  get: jest.fn(() =>
+    Promise.resolve({
+      data: {
+        contracts: [{ contract: 'c1', count: 1 }],
+        users: [{ publicKey: 'u1', pfp: '', count: 1, contracts: ['c1'] }],
+      },
+    })
+  ),
   post: jest.fn(() => Promise.resolve()),
 }));
 
@@ -26,5 +33,6 @@ describe('Trenches page', () => {
     );
     expect(screen.getByText(/Trenches/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /Add Contract/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /My Contracts/i })).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- track contract submissions per user in backend model
- expose contracts in trench API
- allow switching between personal and global bubble maps
- translate UI labels for new buttons
- update unit tests

## Testing
- `yarn test --watchAll=false` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687ba0330d38832aa09813e34ed35eec