### PR TITLE
Add token scanner feature

### DIFF
--- a/backend/src/main/java/com/primos/model/TokenScanResult.java
+++ b/backend/src/main/java/com/primos/model/TokenScanResult.java
@@ -1,0 +1,137 @@
+package com.primos.model;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+import org.bson.codecs.pojo.annotations.BsonId;
+
+import java.time.Instant;
+
+@BsonDiscriminator
+public class TokenScanResult {
+    @BsonId
+    private String tokenAddress;
+    private String name;
+    private String symbol;
+    private Boolean mintAuthorityRevoked;
+    private Boolean freezeAuthorityRevoked;
+    private Boolean lpBurned;
+    private Double liquidityUSD;
+    private Double volume24h;
+    private Integer holders;
+    private Boolean isVerifiedPrimos;
+    private Boolean daoEligible;
+    private Integer riskScore;
+    private String honeypotRisk;
+    private Instant scanTimestamp;
+
+    public String getTokenAddress() {
+        return tokenAddress;
+    }
+
+    public void setTokenAddress(String tokenAddress) {
+        this.tokenAddress = tokenAddress;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public Boolean getMintAuthorityRevoked() {
+        return mintAuthorityRevoked;
+    }
+
+    public void setMintAuthorityRevoked(Boolean mintAuthorityRevoked) {
+        this.mintAuthorityRevoked = mintAuthorityRevoked;
+    }
+
+    public Boolean getFreezeAuthorityRevoked() {
+        return freezeAuthorityRevoked;
+    }
+
+    public void setFreezeAuthorityRevoked(Boolean freezeAuthorityRevoked) {
+        this.freezeAuthorityRevoked = freezeAuthorityRevoked;
+    }
+
+    public Boolean getLpBurned() {
+        return lpBurned;
+    }
+
+    public void setLpBurned(Boolean lpBurned) {
+        this.lpBurned = lpBurned;
+    }
+
+    public Double getLiquidityUSD() {
+        return liquidityUSD;
+    }
+
+    public void setLiquidityUSD(Double liquidityUSD) {
+        this.liquidityUSD = liquidityUSD;
+    }
+
+    public Double getVolume24h() {
+        return volume24h;
+    }
+
+    public void setVolume24h(Double volume24h) {
+        this.volume24h = volume24h;
+    }
+
+    public Integer getHolders() {
+        return holders;
+    }
+
+    public void setHolders(Integer holders) {
+        this.holders = holders;
+    }
+
+    public Boolean getIsVerifiedPrimos() {
+        return isVerifiedPrimos;
+    }
+
+    public void setIsVerifiedPrimos(Boolean isVerifiedPrimos) {
+        this.isVerifiedPrimos = isVerifiedPrimos;
+    }
+
+    public Boolean getDaoEligible() {
+        return daoEligible;
+    }
+
+    public void setDaoEligible(Boolean daoEligible) {
+        this.daoEligible = daoEligible;
+    }
+
+    public Integer getRiskScore() {
+        return riskScore;
+    }
+
+    public void setRiskScore(Integer riskScore) {
+        this.riskScore = riskScore;
+    }
+
+    public String getHoneypotRisk() {
+        return honeypotRisk;
+    }
+
+    public void setHoneypotRisk(String honeypotRisk) {
+        this.honeypotRisk = honeypotRisk;
+    }
+
+    public Instant getScanTimestamp() {
+        return scanTimestamp;
+    }
+
+    public void setScanTimestamp(Instant scanTimestamp) {
+        this.scanTimestamp = scanTimestamp;
+    }
+}

--- a/backend/src/main/java/com/primos/resource/TokenScanResource.java
+++ b/backend/src/main/java/com/primos/resource/TokenScanResource.java
@@ -1,0 +1,26 @@
+package com.primos.resource;
+
+import com.primos.model.TokenScanResult;
+import com.primos.service.TokenScanService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api/token/scan")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class TokenScanResource {
+
+    @Inject
+    TokenScanService scanService;
+
+    @GET
+    @Path("/{tokenAddress}")
+    public TokenScanResult scanToken(@PathParam("tokenAddress") String tokenAddress) {
+        return scanService.scanToken(tokenAddress);
+    }
+}

--- a/backend/src/main/java/com/primos/service/ExternalScanLogic.java
+++ b/backend/src/main/java/com/primos/service/ExternalScanLogic.java
@@ -1,0 +1,15 @@
+package com.primos.service;
+
+import com.primos.model.TokenScanResult;
+
+import java.time.Instant;
+
+public class ExternalScanLogic {
+    public static TokenScanResult performScan(String tokenAddress) {
+        // TODO: Call Solana RPC, Solscan API, Jupiter API, etc.
+        TokenScanResult result = new TokenScanResult();
+        result.setTokenAddress(tokenAddress);
+        result.setScanTimestamp(Instant.now());
+        return result;
+    }
+}

--- a/backend/src/main/java/com/primos/service/TokenScanService.java
+++ b/backend/src/main/java/com/primos/service/TokenScanService.java
@@ -1,0 +1,41 @@
+package com.primos.service;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import com.primos.model.TokenScanResult;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.concurrent.TimeUnit;
+
+@ApplicationScoped
+public class TokenScanService {
+
+    @Inject
+    MongoClient mongoClient;
+
+    private MongoCollection<TokenScanResult> collection;
+
+    @PostConstruct
+    void init() {
+        MongoDatabase db = mongoClient.getDatabase("primos-db");
+        collection = db.getCollection("token_scans", TokenScanResult.class);
+        collection.createIndex(Indexes.ascending("scanTimestamp"),
+                new IndexOptions().expireAfter(3L, TimeUnit.DAYS));
+    }
+
+    public TokenScanResult scanToken(String tokenAddress) {
+        TokenScanResult existing = collection.find(Filters.eq("_id", tokenAddress)).first();
+        if (existing != null) {
+            return existing;
+        }
+        TokenScanResult result = ExternalScanLogic.performScan(tokenAddress);
+        collection.insertOne(result);
+        return result;
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import Experiment1 from './pages/Experiment1';
 import Stickers from './pages/Stickers';
 import Trenches from './pages/Trenches';
 import Docs from './pages/Docs';
+import TokenScanner from './pages/TokenScanner';
 import Admin from './pages/Admin';
 import BetaRedeem from './components/BetaRedeem';
 import LoadingOverlay from './components/LoadingOverlay';
@@ -257,6 +258,7 @@ const AppRoutes = () => {
           <Route path="/" element={<Home />} />
           <Route path="/market" element={<PrimosMarketGallery />} />
           <Route path="/docs" element={<Docs />} />
+          <Route path="/token-scanner" element={<TokenScanner />} />
 
           {publicKey && (isHolder || betaRedeemed) && userExists && (
             <>

--- a/frontend/src/pages/TokenScanner.tsx
+++ b/frontend/src/pages/TokenScanner.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { TextField, Button, Paper, Card, CardContent, Typography, Divider, List, ListItem } from '@mui/material';
+import api from '../utils/api';
+
+interface TokenScanResult {
+  tokenAddress: string;
+  name?: string;
+  symbol?: string;
+  mintAuthorityRevoked?: boolean;
+  freezeAuthorityRevoked?: boolean;
+  lpBurned?: boolean;
+  liquidityUSD?: number;
+  volume24h?: number;
+  holders?: number;
+  isVerifiedPrimos?: boolean;
+  daoEligible?: boolean;
+  riskScore?: number;
+  honeypotRisk?: string;
+}
+
+const TokenScanner: React.FC = () => {
+  const [address, setAddress] = useState('');
+  const [result, setResult] = useState<TokenScanResult | null>(null);
+
+  const handleScan = async (addr: string) => {
+    try {
+      const res = await api.get<TokenScanResult>(`/api/token/scan/${addr}`);
+      setResult(res.data);
+    } catch {
+      setResult(null);
+    }
+  };
+
+  return (
+    <div className="experiment-container">
+      <Paper elevation={3} style={{ padding: '1rem', marginBottom: '1rem' }}>
+        <TextField
+          fullWidth
+          label="Paste Token Address"
+          variant="outlined"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          margin="normal"
+        />
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => handleScan(address)}
+          disabled={!address}
+        >
+          Scan Token
+        </Button>
+      </Paper>
+      {result && (
+        <Card>
+          <CardContent>
+            <Typography variant="h6">
+              {result.name} ({result.symbol})
+            </Typography>
+            <Divider sx={{ my: 1 }} />
+            <List>
+              <ListItem>
+                Mint Authority Revoked: {result.mintAuthorityRevoked ? '✅' : '❌'}
+              </ListItem>
+              <ListItem>
+                Freeze Authority Revoked: {result.freezeAuthorityRevoked ? '✅' : '❌'}
+              </ListItem>
+              <ListItem>Liquidity: ${result.liquidityUSD}</ListItem>
+              <ListItem>Volume (24h): ${result.volume24h}</ListItem>
+              <ListItem>Risk Score: {result.riskScore}/100</ListItem>
+              <ListItem>Honeypot Risk: {result.honeypotRisk}</ListItem>
+              <ListItem>Holders: {result.holders}</ListItem>
+            </List>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default TokenScanner;


### PR DESCRIPTION
## Summary
- create new backend model `TokenScanResult`
- implement `TokenScanService` with TTL index and scanning logic placeholder
- expose REST endpoint `/api/token/scan/{tokenAddress}`
- add frontend page `TokenScanner`
- register page route in `App.tsx`

## Testing
- `npm test` *(fails: craco not found and packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ba437aa34832abda66a31720ffccd