### PR TITLE
Add Primo Art Team work group

### DIFF
--- a/backend/src/main/java/com/primos/model/User.java
+++ b/backend/src/main/java/com/primos/model/User.java
@@ -17,6 +17,7 @@ public class User extends PanacheMongoEntity {
     private int pesos = 1;
     private boolean primoHolder = false;
     private boolean daoMember = true;
+    private boolean artTeam = false;
     private String betaCode;
     private boolean betaRedeemed = false;
     private long createdAt = System.currentTimeMillis();
@@ -116,6 +117,14 @@ public class User extends PanacheMongoEntity {
 
     public void setDaoMember(boolean daoMember) {
         this.daoMember = daoMember;
+    }
+
+    public boolean isArtTeam() {
+        return artTeam;
+    }
+
+    public void setArtTeam(boolean artTeam) {
+        this.artTeam = artTeam;
     }
 
     public String getBetaCode() {

--- a/backend/src/main/java/com/primos/model/WorkRequest.java
+++ b/backend/src/main/java/com/primos/model/WorkRequest.java
@@ -1,0 +1,20 @@
+package com.primos.model;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+
+@MongoEntity(collection = "workrequests")
+public class WorkRequest extends PanacheMongoEntity {
+    private String requester;
+    private String description;
+    private long createdAt = System.currentTimeMillis();
+
+    public String getRequester() { return requester; }
+    public void setRequester(String requester) { this.requester = requester; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public long getCreatedAt() { return createdAt; }
+    public void setCreatedAt(long createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/com/primos/resource/WorkResource.java
+++ b/backend/src/main/java/com/primos/resource/WorkResource.java
@@ -1,0 +1,31 @@
+package com.primos.resource;
+
+import com.primos.model.WorkRequest;
+import com.primos.service.WorkRequestService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+
+@Path("/api/work")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class WorkResource {
+
+    @Inject
+    WorkRequestService service;
+
+    @GET
+    public List<WorkRequest> list() {
+        return service.list();
+    }
+
+    @POST
+    public WorkRequest create(@HeaderParam("X-Public-Key") String publicKey, WorkRequest req) {
+        if (publicKey == null || publicKey.isEmpty()) {
+            throw new BadRequestException();
+        }
+        String desc = req != null ? req.getDescription() : null;
+        return service.add(publicKey, desc == null ? "" : desc);
+    }
+}

--- a/backend/src/main/java/com/primos/service/LoginService.java
+++ b/backend/src/main/java/com/primos/service/LoginService.java
@@ -123,6 +123,7 @@ public class LoginService {
         user.setCreatedAt(System.currentTimeMillis());
         user.setDaoMember(holder);
         user.setPrimoHolder(holder);
+        user.setArtTeam(false);
         return user;
     }
 

--- a/backend/src/main/java/com/primos/service/ProfileService.java
+++ b/backend/src/main/java/com/primos/service/ProfileService.java
@@ -29,6 +29,7 @@ public class ProfileService {
                 }
                 user.setDomain(lower);
             }
+            user.setArtTeam(updated.isArtTeam());
             user.persistOrUpdate();
         }
         return user;

--- a/backend/src/main/java/com/primos/service/WorkRequestService.java
+++ b/backend/src/main/java/com/primos/service/WorkRequestService.java
@@ -1,0 +1,20 @@
+package com.primos.service;
+
+import com.primos.model.WorkRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+@ApplicationScoped
+public class WorkRequestService {
+    public WorkRequest add(String requester, String description) {
+        WorkRequest w = new WorkRequest();
+        w.setRequester(requester);
+        w.setDescription(description);
+        w.persist();
+        return w;
+    }
+
+    public List<WorkRequest> list() {
+        return WorkRequest.listAll();
+    }
+}

--- a/backend/src/test/java/com/primos/resource/WorkResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/WorkResourceTest.java
@@ -1,0 +1,21 @@
+package com.primos.resource;
+
+import com.primos.model.WorkRequest;
+import com.primos.service.WorkRequestService;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+
+public class WorkResourceTest {
+    @Test
+    public void testCreateAndList() {
+        WorkResource res = new WorkResource();
+        res.service = new WorkRequestService();
+        WorkRequest req = new WorkRequest();
+        req.setDescription("paint a primo");
+        res.create("collector1", req);
+        List<WorkRequest> list = res.list();
+        assertEquals(1, list.size());
+        assertEquals("collector1", list.get(0).getRequester());
+    }
+}

--- a/backend/src/test/java/com/primos/service/ProfileServiceTest.java
+++ b/backend/src/test/java/com/primos/service/ProfileServiceTest.java
@@ -39,4 +39,20 @@ public class ProfileServiceTest {
         updated.setDomain("taken.sol");
         assertThrows(jakarta.ws.rs.BadRequestException.class, () -> svc.updateProfile("w2", "w2", updated));
     }
+
+    @Test
+    public void testUpdateArtTeamFlag() {
+        User u = new User();
+        u.setPublicKey("wg1");
+        u.persist();
+
+        ProfileService svc = new ProfileService();
+        User updated = new User();
+        updated.setPublicKey("wg1");
+        updated.setArtTeam(true);
+        svc.updateProfile("wg1", "wg1", updated);
+
+        User db = User.find("publicKey", "wg1").firstResult();
+        assertTrue(db.isArtTeam());
+    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import Trenches from './pages/Trenches';
 import Docs from './pages/Docs';
 import TokenScanner from './pages/TokenScanner';
 import Admin from './pages/Admin';
+import Work from './pages/Work';
 import BetaRedeem from './components/BetaRedeem';
 import LoadingOverlay from './components/LoadingOverlay';
 
@@ -207,7 +208,7 @@ const Header: React.FC = () => {
 
 const AppRoutes = () => {
   const { publicKey } = useWallet();
-  const { isHolder, betaRedeemed, userExists } = usePrimoHolder();
+  const { isHolder, betaRedeemed, userExists, artTeam } = usePrimoHolder();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -231,6 +232,9 @@ const AppRoutes = () => {
       navigate('/', { replace: true });
     }
     if ((!publicKey || (!isHolder && !betaRedeemed)) && location.pathname === '/trenches') {
+      navigate('/', { replace: true });
+    }
+    if ((!publicKey || (!isHolder && !betaRedeemed) || !artTeam) && location.pathname === '/work') {
       navigate('/', { replace: true });
     }
     if (
@@ -267,6 +271,7 @@ const AppRoutes = () => {
               <Route path="/experiment1" element={<Experiment1 />} />
               <Route path="/stickers" element={<Stickers />} />
               <Route path="/trenches" element={<Trenches />} />
+              {artTeam && <Route path="/work" element={<Work />} />}
               <Route path="/profile"   element={<UserProfile />} />
               <Route path="/user/:publicKey" element={<UserProfile />} />
             </>

--- a/frontend/src/components/SidebarNav.tsx
+++ b/frontend/src/components/SidebarNav.tsx
@@ -22,7 +22,7 @@ const SidebarNav: React.FC = () => {
   const { t } = useTranslation();
   const location = useLocation();
   const { publicKey } = useWallet();
-  const { isHolder, betaRedeemed, userExists } = usePrimoHolder();
+  const { isHolder, betaRedeemed, userExists, artTeam } = usePrimoHolder();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [open, setOpen] = useState(false);
@@ -36,6 +36,12 @@ const SidebarNav: React.FC = () => {
       icon: <WorkIcon />,
       label: t('your_primos_nfts'),
       show: publicKey && (isHolder || betaRedeemed) && userExists,
+    },
+    {
+      to: '/work',
+      icon: <WorkIcon />,
+      label: t('work_title'),
+      show: publicKey && (isHolder || betaRedeemed) && userExists && artTeam,
     },
     {
       to: '/labs',

--- a/frontend/src/contexts/PrimoHolderContext.tsx
+++ b/frontend/src/contexts/PrimoHolderContext.tsx
@@ -7,6 +7,7 @@ interface PrimoHolderContextValue {
   isHolder: boolean;
   userExists: boolean;
   betaRedeemed: boolean;
+  artTeam: boolean;
   showRedeemDialog: boolean;
   setShowRedeemDialog(open: boolean): void;
   redeemBetaCode(code: string): Promise<void>;
@@ -21,6 +22,7 @@ export const PrimoHolderProvider: React.FC<React.PropsWithChildren<{}>> = ({ chi
   const [isHolder, setIsHolder] = useState(false);
   const [userExists, setUserExists] = useState(false);
   const [betaRedeemed, setBetaRedeemed] = useState(false);
+  const [artTeam, setArtTeam] = useState(false);
   const [showRedeemDialog, setShowRedeemDialog] = useState(false);
 
   // whenever publicKey changes, fetch user record and check blockchain holder status
@@ -58,6 +60,7 @@ export const PrimoHolderProvider: React.FC<React.PropsWithChildren<{}>> = ({ chi
         const user = userRes.data;
         setUserExists(!!user?.publicKey);
         setBetaRedeemed(!!user?.betaRedeemed);
+        setArtTeam(!!user?.artTeam);
       } catch (err) {
         console.error('[PrimoHolderContext] Error in fetchData:', err);
         setUserExists(false);
@@ -97,6 +100,7 @@ export const PrimoHolderProvider: React.FC<React.PropsWithChildren<{}>> = ({ chi
       isHolder,
       userExists,
       betaRedeemed,
+      artTeam,
       showRedeemDialog,
       setShowRedeemDialog,
       redeemBetaCode,
@@ -106,6 +110,7 @@ export const PrimoHolderProvider: React.FC<React.PropsWithChildren<{}>> = ({ chi
       isHolder,
       userExists,
       betaRedeemed,
+      artTeam,
       showRedeemDialog,
       setShowRedeemDialog,
       redeemBetaCode,

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -182,10 +182,14 @@
   "experiment2_desc": "Order stickers of your Primo NFTs with QR codes linking back to the marketplace and your socials. 5% of the cost goes to the DAO.",
   "order_sticker": "Order Sticker",
   "stickers_order_thanks": "Sticker ordering coming soon!"
-  ,"experiment3_title": "Trenches"
-  ,"experiment3_desc": "Enter contract addresses to grow the trenches. Bubbles expand as more users join."
-  ,"enter_contract": "Enter contract address"
-  ,"add_contract": "Add Contract"
-  ,"my_contracts": "My Contracts"
-  ,"all_users": "All Users"
+ ,"experiment3_title": "Trenches"
+ ,"experiment3_desc": "Enter contract addresses to grow the trenches. Bubbles expand as more users join."
+ ,"enter_contract": "Enter contract address"
+ ,"add_contract": "Add Contract"
+ ,"my_contracts": "My Contracts"
+ ,"all_users": "All Users"
+ ,"work_title": "Work Requests"
+ ,"work_join_label": "Join Primo Art Team"
+ ,"work_request_placeholder": "Describe your request"
+ ,"work_submit": "Submit"
 }

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -182,10 +182,14 @@
   "experiment2_desc": "Ordena calcomanías de tus Primos NFTs con códigos QR que enlazan al marketplace y a tus redes. El 5% del costo apoya al DAO.",
   "order_sticker": "Pedir calcomanía",
   "stickers_order_thanks": "¡Pronto podrás completar tu pedido!"
-  ,"experiment3_title": "Trincheras"
-  ,"experiment3_desc": "Ingresa direcciones de contrato para hacer crecer las trincheras. Las burbujas aumentan al unirse más usuarios."
-  ,"enter_contract": "Ingresa dirección de contrato"
-  ,"add_contract": "Agregar Contrato"
-  ,"my_contracts": "Mis Contratos"
-  ,"all_users": "Todos los Usuarios"
+ ,"experiment3_title": "Trincheras"
+ ,"experiment3_desc": "Ingresa direcciones de contrato para hacer crecer las trincheras. Las burbujas aumentan al unirse más usuarios."
+ ,"enter_contract": "Ingresa dirección de contrato"
+ ,"add_contract": "Agregar Contrato"
+ ,"my_contracts": "Mis Contratos"
+ ,"all_users": "Todos los Usuarios"
+ ,"work_title": "Solicitudes de Arte"
+ ,"work_join_label": "Unirse al Equipo de Arte Primo"
+ ,"work_request_placeholder": "Describe tu solicitud"
+ ,"work_submit": "Enviar"
 }

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -7,7 +7,7 @@ import { keyframes } from '@emotion/react';
 import './UserProfile.css';
 import { useTranslation } from 'react-i18next';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Box, Typography, TextField, Button, Avatar, IconButton, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { Box, Typography, TextField, Button, Avatar, IconButton, FormControl, InputLabel, Select, MenuItem, Checkbox, FormControlLabel } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CircleIcon from '@mui/icons-material/Circle';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
@@ -33,6 +33,7 @@ type UserDoc = {
   pointsToday: number;
   pointsDate: string;
   pesos: number;
+  artTeam: boolean;
 };
 
 const getStatus = (count: number) => {
@@ -338,6 +339,18 @@ const fadeOut = keyframes`
           margin="normal"
           disabled={!isOwner || !isEditing}
         />
+        {isOwner && (
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={user.artTeam}
+                onChange={(e) => setUser({ ...user, artTeam: e.target.checked })}
+                disabled={!isEditing}
+              />
+            }
+            label={t('work_join_label')}
+          />
+        )}
         <TextField
           label={t('sns_domain')}
           value={primaryDomain || ''}

--- a/frontend/src/pages/Work.tsx
+++ b/frontend/src/pages/Work.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import api from '../utils/api';
+
+interface WorkRequest {
+  requester: string;
+  description: string;
+  createdAt: number;
+}
+
+const Work: React.FC = () => {
+  const { t } = useTranslation();
+  const [requests, setRequests] = useState<WorkRequest[]>([]);
+  const [desc, setDesc] = useState('');
+
+  useEffect(() => {
+    api.get<WorkRequest[]>('/api/work').then(res => setRequests(res.data)).catch(() => setRequests([]));
+  }, []);
+
+  const submit = async () => {
+    await api.post('/api/work', { description: desc });
+    const res = await api.get<WorkRequest[]>('/api/work');
+    setRequests(res.data);
+    setDesc('');
+  };
+
+  return (
+    <Box>
+      <h2>{t('work_title')}</h2>
+      <Box mb={2}>
+        <TextField fullWidth value={desc} onChange={e => setDesc(e.target.value)} placeholder={t('work_request_placeholder') || ''} />
+        <Button variant="contained" sx={{ mt: 1 }} onClick={submit}>{t('work_submit')}</Button>
+      </Box>
+      {requests.map((r, i) => (
+        <Box key={i} sx={{ mb:1, p:1, border:'1px solid #ccc' }}>
+          <strong>{r.requester}</strong>: {r.description}
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default Work;

--- a/frontend/src/pages/__tests__/Work.test.tsx
+++ b/frontend/src/pages/__tests__/Work.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Work from '../Work';
+
+jest.mock('../../utils/api', () => ({
+  get: jest.fn(() => Promise.resolve({ data: [] })),
+  post: jest.fn(() => Promise.resolve({ data: {} }))
+}));
+
+describe('Work page', () => {
+  test('renders title and submits request', async () => {
+    render(
+      <MemoryRouter>
+        <Work />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Work Requests/i)).toBeTruthy();
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'test' } });
+    fireEvent.click(screen.getByText(/Submit/i));
+    expect(await screen.findByRole('textbox')).toHaveValue('');
+  });
+});


### PR DESCRIPTION
## Summary
- enable art team membership on profiles
- list and create work requests via new backend resource
- add Work page gated to art team holders
- update i18n strings for the new feature
- test profile update and work resource
- add simple frontend tests for Work page

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm install` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687bab101d04832aafc0b17e7d7d924e