### PR TITLE
Fix WorkResourceTest compilation error

### DIFF
--- a/backend/src/test/java/com/primos/resource/WorkResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/WorkResourceTest.java
@@ -14,7 +14,7 @@ public class WorkResourceTest {
         WorkRequest req = new WorkRequest();
         req.setDescription("paint a primo");
         res.create("collector1", req);
-        List<WorkRequest> list = res.list();
+        List<WorkRequest> list = res.list(null);
         assertEquals(1, list.size());
         assertEquals("collector1", list.get(0).getRequester());
     }


### PR DESCRIPTION
## Summary
- call `WorkResource.list()` with null group parameter so it matches method signature

## Testing
- `mvn -q -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 test` *(fails: NotificationServiceTest.testAddAndFetch et al.)*
- `npm test -- --watchAll=false` *(fails to run multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_687bc79d2d24832aa51d5f1c39130eab