### PR TITLE
Enable Work page for all holders

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -234,7 +234,7 @@ const AppRoutes = () => {
     if ((!publicKey || (!isHolder && !betaRedeemed)) && location.pathname === '/trenches') {
       navigate('/', { replace: true });
     }
-    if ((!publicKey || (!isHolder && !betaRedeemed) || !artTeam) && location.pathname === '/work') {
+    if ((!publicKey || (!isHolder && !betaRedeemed)) && location.pathname === '/work') {
       navigate('/', { replace: true });
     }
     if (
@@ -271,7 +271,7 @@ const AppRoutes = () => {
               <Route path="/experiment1" element={<Experiment1 />} />
               <Route path="/stickers" element={<Stickers />} />
               <Route path="/trenches" element={<Trenches />} />
-              {artTeam && <Route path="/work" element={<Work />} />}
+              <Route path="/work" element={<Work />} />
               <Route path="/profile"   element={<UserProfile />} />
               <Route path="/user/:publicKey" element={<UserProfile />} />
             </>

--- a/frontend/src/components/SidebarNav.tsx
+++ b/frontend/src/components/SidebarNav.tsx
@@ -42,7 +42,7 @@ const SidebarNav: React.FC = () => {
       to: '/work',
       icon: <ConstructionIcon />,
       label: t('work_title'),
-      show: publicKey && (isHolder || betaRedeemed) && userExists && artTeam,
+      show: publicKey && (isHolder || betaRedeemed) && userExists,
     },
     {
       to: '/labs',


### PR DESCRIPTION
## Summary
- show Work page for Primo holders in Sidebar
- allow holders to access `/work` route

## Testing
- `CI=true npm test -- -w=0` *(fails: Cannot find module 'react-router-dom', axios ESM issues)*

------
https://chatgpt.com/codex/tasks/task_e_687c6bd09640832aaf0412637d6f5171