### PR TITLE
Improve holder status check

### DIFF
--- a/frontend/src/utils/__tests__/helius.test.ts
+++ b/frontend/src/utils/__tests__/helius.test.ts
@@ -65,9 +65,11 @@ describe('helius utilities', () => {
   });
 
   test('checkPrimoHolder returns true when collection has NFTs', async () => {
-    jest
-      .spyOn(require('../helius'), 'getAssetsByCollection')
-      .mockResolvedValueOnce([{ id: '1' }]);
+    const response = {
+      ok: true,
+      json: async () => ({ result: { items: [{ id: '1' }] } }),
+    };
+    (global as any).fetch = jest.fn().mockResolvedValue(response);
     const result = await checkPrimoHolder('col', 'owner');
     expect(result).toBe(true);
   });


### PR DESCRIPTION
## Summary
- speed up Primo holder verification
- update helius utility tests

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c74943f3c832a94b750ccfbac08c6