### PR TITLE
Fix malformed JSON translations

### DIFF
--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -187,7 +187,7 @@
  ,"enter_contract": "Enter contract address"
  ,"add_contract": "Add Contract"
  ,"my_contracts": "My Contracts"
- ,"all_users": "All Users",
+ ,"all_users": "All Users"
  ,"all_contracts": "All Contracts"
  ,"no_scans": "You have not scanned any contracts yet."
  ,"work_title": "Work Requests"

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -187,7 +187,7 @@
  ,"enter_contract": "Ingresa dirección de contrato"
  ,"add_contract": "Agregar Contrato"
  ,"my_contracts": "Mis Contratos"
- ,"all_users": "Todos los Usuarios",
+ ,"all_users": "Todos los Usuarios"
  ,"all_contracts": "Todos los Contratos"
  ,"no_scans": "Aún no has escaneado contratos."
  ,"work_title": "Solicitudes de Arte"


### PR DESCRIPTION
## Summary
- fix trailing commas in translations that caused JSON parse failure

## Testing
- `jq . frontend/src/locales/en/en.json`
- `jq . src/locales/es/es.json`
- `npm test --silent -- --watchAll=false` *(fails: cannot find module 'react-router-dom' and multiple unit test errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c74eeaef8832a85ba3a0a37aa6a76