### PR TITLE
Add Telegram panel for contract bubbles

### DIFF
--- a/frontend/src/components/TelegramPanel.css
+++ b/frontend/src/components/TelegramPanel.css
@@ -1,0 +1,47 @@
+.telegram-overlay {
+  background: rgba(0, 0, 0, 0.6);
+  position: fixed;
+  inset: 0;
+}
+
+.telegram-content {
+  background: rgba(30, 30, 30, 0.9);
+  color: #fff;
+  border: 1px solid #888;
+  border-radius: 8px;
+  padding: 1rem;
+  width: 90vw;
+  max-width: 380px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.telegram-close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  color: #fff;
+}
+
+.telegram-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.telegram-row {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.4rem;
+  border-radius: 4px;
+}
+
+@media (min-width: 700px) {
+  .telegram-content {
+    max-width: 500px;
+  }
+}

--- a/frontend/src/components/TelegramPanel.tsx
+++ b/frontend/src/components/TelegramPanel.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useTranslation } from 'react-i18next';
+import { fetchTelegramData, TelegramEntry } from '../services/telegram';
+import './TelegramPanel.css';
+
+interface TelegramPanelProps {
+  contract: string | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+const TelegramPanel: React.FC<TelegramPanelProps> = ({ contract, open, onClose }) => {
+  const [entries, setEntries] = useState<TelegramEntry[]>([]);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!contract || !open) return;
+    fetchTelegramData(contract).then(setEntries);
+  }, [contract, open]);
+
+  if (!contract) return null;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Overlay className="telegram-overlay" />
+      <Dialog.Content className="telegram-content">
+        <IconButton
+          className="telegram-close"
+          onClick={onClose}
+          aria-label={t('close')}
+          size="small"
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+        <Typography variant="h6" sx={{ mb: 1 }}>
+          {t('telegram_data')}
+        </Typography>
+        <Box className="telegram-list">
+          {entries.map((e) => (
+            <Box key={e.id} className="telegram-row">
+              <Typography variant="body2">{e.message}</Typography>
+              <Typography variant="caption">
+                {new Date(e.time).toLocaleString()}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+
+export default TelegramPanel;

--- a/frontend/src/components/__tests__/TelegramPanel.test.tsx
+++ b/frontend/src/components/__tests__/TelegramPanel.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../i18n';
+import TelegramPanel from '../TelegramPanel';
+import * as service from '../../services/telegram';
+
+jest.mock('../../services/telegram');
+
+describe('TelegramPanel', () => {
+  test('renders telegram data', async () => {
+    (service.fetchTelegramData as jest.Mock).mockResolvedValueOnce([
+      { id: '1', message: 'hi', time: '2024-01-01T00:00:00Z' },
+    ]);
+    render(
+      <I18nextProvider i18n={i18n}>
+        <TelegramPanel contract="c1" open={true} onClose={() => {}} />
+      </I18nextProvider>
+    );
+    expect(await screen.findByText('hi')).toBeTruthy();
+    expect(service.fetchTelegramData).toHaveBeenCalledWith('c1');
+  });
+
+  test('calls onClose', async () => {
+    (service.fetchTelegramData as jest.Mock).mockResolvedValueOnce([]);
+    const onClose = jest.fn();
+    render(
+      <I18nextProvider i18n={i18n}>
+        <TelegramPanel contract="c1" open={true} onClose={onClose} />
+      </I18nextProvider>
+    );
+    const btn = await screen.findByLabelText(/close/i);
+    fireEvent.click(btn);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -196,9 +196,10 @@
  ,"work_art": "Art"
  ,"work_dev": "Dev"
  ,"work_other": "Other"
- ,"work_request_placeholder": "Describe your request"
- ,"work_submit": "Submit"
+  ,"work_request_placeholder": "Describe your request"
+  ,"work_submit": "Submit"
   ,"work_pick": "Pick Up"
   ,"work_assigned_to": "Assigned to"
   ,"work_no_groups": "You are not part of any work groups. Join one in your profile."
+  ,"telegram_data": "Telegram Data"
 }

--- a/frontend/src/pages/Trenches.tsx
+++ b/frontend/src/pages/Trenches.tsx
@@ -7,6 +7,7 @@ import Avatar from '@mui/material/Avatar';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { useTranslation } from 'react-i18next';
 import { fetchTrenchData, submitTrenchContract } from '../services/trench';
+import TelegramPanel from '../components/TelegramPanel';
 import './Trenches.css';
 
 interface TrenchContract {
@@ -33,6 +34,7 @@ const Trenches: React.FC = () => {
   const [data, setData] = useState<TrenchData>({ contracts: [], users: [] });
   const [tab, setTab] = useState<'my' | 'users' | 'contracts'>('my');
   const [selectedUser, setSelectedUser] = useState<TrenchUser | null>(null);
+  const [openContract, setOpenContract] = useState<string | null>(null);
 
   const multiContracts = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -135,6 +137,7 @@ const Trenches: React.FC = () => {
                       key={c}
                       className="bubble"
                       sx={{ width: size, height: size, fontSize: size / 5 }}
+                      onClick={() => setOpenContract(c)}
                     >
                       {short}
                     </Box>
@@ -189,6 +192,7 @@ const Trenches: React.FC = () => {
                     key={c}
                     className="bubble"
                     sx={{ width: size, height: size, fontSize: size / 5 }}
+                    onClick={() => setOpenContract(c)}
                   >
                     {short}
                   </Box>
@@ -218,6 +222,7 @@ const Trenches: React.FC = () => {
                     key={c.contract}
                     className="bubble"
                     sx={{ width: size, height: size, fontSize: size / 5 }}
+                    onClick={() => setOpenContract(c.contract)}
                   >
                     {short}
                   </Box>
@@ -227,6 +232,11 @@ const Trenches: React.FC = () => {
           )}
         </>
       )}
+      <TelegramPanel
+        contract={openContract}
+        open={openContract !== null}
+        onClose={() => setOpenContract(null)}
+      />
     </Box>
   );
 };

--- a/frontend/src/pages/__tests__/Trenches.test.tsx
+++ b/frontend/src/pages/__tests__/Trenches.test.tsx
@@ -5,6 +5,7 @@ import { I18nextProvider } from 'react-i18next';
 import i18n from '../../i18n';
 import Trenches from '../Trenches';
 import * as trenchService from '../../services/trench';
+import * as telegramService from '../../services/telegram';
 
 jest.mock('../../services/trench', () => ({
   fetchTrenchData: jest.fn(() =>
@@ -14,6 +15,9 @@ jest.mock('../../services/trench', () => ({
     })
   ),
   submitTrenchContract: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('../../services/telegram', () => ({
+  fetchTelegramData: jest.fn(() => Promise.resolve([])),
 }));
 
 describe('Trenches page', () => {
@@ -68,5 +72,25 @@ describe('Trenches page', () => {
     allContractsButton.click();
 
     expect(await screen.findByText('c1')).toBeTruthy();
+  });
+
+  test('opens telegram panel on bubble click', async () => {
+    (trenchService.fetchTrenchData as jest.Mock).mockResolvedValueOnce({
+      contracts: [{ contract: 'c1', count: 1 }],
+      users: [{ publicKey: 'u1', pfp: '', count: 1, contracts: ['c1'] }],
+    });
+    render(
+      <MemoryRouter>
+        <I18nextProvider i18n={i18n}>
+          <Trenches />
+        </I18nextProvider>
+      </MemoryRouter>
+    );
+    const allBtn = screen.getByRole('button', { name: /All Contracts/i });
+    allBtn.click();
+    const bubble = await screen.findByText('c1');
+    bubble.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(telegramService.fetchTelegramData).toHaveBeenCalledWith('c1');
+    expect(await screen.findByText(/Telegram Data/i)).toBeTruthy();
   });
 });

--- a/frontend/src/services/__tests__/telegram.test.ts
+++ b/frontend/src/services/__tests__/telegram.test.ts
@@ -1,0 +1,12 @@
+import { fetchTelegramData } from '../telegram';
+import api from '../../utils/api';
+
+jest.mock('../../utils/api');
+
+describe('telegram service', () => {
+  test('fetchTelegramData calls api', async () => {
+    (api.get as jest.Mock).mockResolvedValue({ data: [] });
+    await fetchTelegramData('c1');
+    expect(api.get).toHaveBeenCalledWith('/api/telegram/c1');
+  });
+});

--- a/frontend/src/services/telegram.ts
+++ b/frontend/src/services/telegram.ts
@@ -1,0 +1,14 @@
+export interface TelegramEntry {
+  id: string;
+  message: string;
+  time: string;
+}
+
+import api from '../utils/api';
+
+export const fetchTelegramData = async (
+  contract: string
+): Promise<TelegramEntry[]> => {
+  const res = await api.get<TelegramEntry[]>(`/api/telegram/${contract}`);
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- create TelegramPanel UI component and styling
- fetch contract telegram data with new service
- open TelegramPanel when clicking contract bubbles
- update translations
- test TelegramPanel, Trenches bubble action, and telegram service

## Testing
- `npm test` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c7fb7f5e8832ab62deacadc887fb6