### PR TITLE
Fix card layout on mobile for long translations

### DIFF
--- a/frontend/src/components/TransactionCard.css
+++ b/frontend/src/components/TransactionCard.css
@@ -44,6 +44,8 @@
   }
 
   .transaction-card-mobile {
+    width: 100%;
+    max-width: 100%;
     padding: 0.5rem;
     border-radius: 0.4rem;
     margin: 0;

--- a/frontend/src/pages/PrimosMarketGallery.css
+++ b/frontend/src/pages/PrimosMarketGallery.css
@@ -346,6 +346,7 @@
   position: relative;
   border: 1px solid #222;
   background: #fff;
+  width: 100%;
 }
 
 .nft-gallery-grid.market-nft-list.nft-list>*:hover {


### PR DESCRIPTION
## Summary
- set fixed width for `transaction-card-mobile`
- ensure NFT gallery grid items cannot exceed their column width

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm test -- --watchAll=false` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d0a6725ec832aaa26bcd05dec1b16