### PR TITLE
Add CoinGecko stats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The project integrates with Meshy.ai for converting images to 3D models. Provide
 your API key via the `MESHY_API_KEY` variable in `.env` so the backend can
 authenticate requests.
 
+Token stats shown in the Telegram panel come from the
+[CoinGecko API](https://docs.coingecko.com/v3.0.1/reference/coins-contract-address).
+Set `COINGECKO_API_BASE` if you need to override the default endpoint.
+
 ### Beta Access
 
 The backend restricts logins to users with a valid beta code. Thirty beta codes

--- a/backend/src/main/java/com/primos/model/TelegramData.java
+++ b/backend/src/main/java/com/primos/model/TelegramData.java
@@ -1,0 +1,49 @@
+package com.primos.model;
+
+public class TelegramData {
+    private String tokenAddress;
+    private Double priceUsd;
+    private Double fdvUsd;
+    private Double volume24hUsd;
+    private Double change1hPercent;
+
+    public String getTokenAddress() {
+        return tokenAddress;
+    }
+
+    public void setTokenAddress(String tokenAddress) {
+        this.tokenAddress = tokenAddress;
+    }
+
+    public Double getPriceUsd() {
+        return priceUsd;
+    }
+
+    public void setPriceUsd(Double priceUsd) {
+        this.priceUsd = priceUsd;
+    }
+
+    public Double getFdvUsd() {
+        return fdvUsd;
+    }
+
+    public void setFdvUsd(Double fdvUsd) {
+        this.fdvUsd = fdvUsd;
+    }
+
+    public Double getVolume24hUsd() {
+        return volume24hUsd;
+    }
+
+    public void setVolume24hUsd(Double volume24hUsd) {
+        this.volume24hUsd = volume24hUsd;
+    }
+
+    public Double getChange1hPercent() {
+        return change1hPercent;
+    }
+
+    public void setChange1hPercent(Double change1hPercent) {
+        this.change1hPercent = change1hPercent;
+    }
+}

--- a/backend/src/main/java/com/primos/resource/TelegramResource.java
+++ b/backend/src/main/java/com/primos/resource/TelegramResource.java
@@ -1,0 +1,28 @@
+package com.primos.resource;
+
+import com.primos.model.TelegramData;
+import com.primos.service.CoingeckoService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api/telegram")
+@Produces(MediaType.APPLICATION_JSON)
+public class TelegramResource {
+
+    @Inject
+    CoingeckoService coingeckoService;
+
+    @GET
+    @Path("/{contract}")
+    public TelegramData getData(@PathParam("contract") String contract) {
+        TelegramData data = coingeckoService.fetchTokenData(contract);
+        if (data == null) {
+            return new TelegramData();
+        }
+        return data;
+    }
+}

--- a/backend/src/main/java/com/primos/service/CoingeckoService.java
+++ b/backend/src/main/java/com/primos/service/CoingeckoService.java
@@ -1,0 +1,81 @@
+package com.primos.service;
+
+import com.primos.model.TelegramData;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class CoingeckoService {
+    private static final Logger LOG = Logger.getLogger(CoingeckoService.class.getName());
+    private static final String API_BASE = System.getenv().getOrDefault("COINGECKO_API_BASE",
+            "https://api.coingecko.com/api/v3");
+    private static final HttpClient CLIENT = createClient();
+
+    private static HttpClient createClient() {
+        String proxy = System.getenv("https_proxy");
+        if (proxy == null || proxy.isEmpty()) {
+            proxy = System.getenv("HTTPS_PROXY");
+        }
+        if (proxy != null && !proxy.isEmpty()) {
+            try {
+                URI uri = URI.create(proxy);
+                return HttpClient.newBuilder()
+                        .proxy(ProxySelector.of(new InetSocketAddress(uri.getHost(), uri.getPort())))
+                        .build();
+            } catch (Exception ignored) {
+            }
+        }
+        return HttpClient.newHttpClient();
+    }
+
+    public TelegramData fetchTokenData(String contract) {
+        try {
+            String url = API_BASE + "/coins/solana/contract/" + contract;
+            HttpRequest req = HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
+            HttpResponse<String> resp = CLIENT.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200) {
+                LOG.warning("Coingecko response status: " + resp.statusCode());
+                return null;
+            }
+            try (JsonReader reader = Json.createReader(new StringReader(resp.body()))) {
+                JsonObject obj = reader.readObject();
+                JsonObject market = obj.getJsonObject("market_data");
+                if (market == null) {
+                    return null;
+                }
+                TelegramData data = new TelegramData();
+                data.setTokenAddress(contract);
+                JsonObject priceObj = market.getJsonObject("current_price");
+                if (priceObj != null && priceObj.containsKey("usd")) {
+                    data.setPriceUsd(priceObj.getJsonNumber("usd").doubleValue());
+                }
+                JsonObject fdvObj = market.getJsonObject("fully_diluted_valuation");
+                if (fdvObj != null && fdvObj.containsKey("usd")) {
+                    data.setFdvUsd(fdvObj.getJsonNumber("usd").doubleValue());
+                }
+                JsonObject volObj = market.getJsonObject("total_volume");
+                if (volObj != null && volObj.containsKey("usd")) {
+                    data.setVolume24hUsd(volObj.getJsonNumber("usd").doubleValue());
+                }
+                JsonObject changeObj = market.getJsonObject("price_change_percentage_1h_in_currency");
+                if (changeObj != null && changeObj.containsKey("usd")) {
+                    data.setChange1hPercent(changeObj.getJsonNumber("usd").doubleValue());
+                }
+                return data;
+            }
+        } catch (Exception e) {
+            LOG.warning("Failed to fetch Coingecko data: " + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,6 +7,7 @@ REACT_APP_MAGICEDEN_BASE=/api/proxy
 REACT_APP_HELIUS_API_KEY=your-helius-api-key
 MAGICEDEN_API_KEY=your-magic-eden-api-key
 MESHY_API_KEY=your-meshy-api-key
+COINGECKO_API_BASE=https://api.coingecko.com/api/v3
 QUARKUS_PROFILE=dev
 QUARKUS_MONGODB_CONNECTION_STRING=mongodb://localhost:27017/primos-db
 REACT_APP_ADMIN_WALLET=EB5uzfZZrWQ8BPEmMNrgrNMNCHR1qprrsspHNNgVEZa6


### PR DESCRIPTION
## Summary
- integrate CoinGecko API for Telegram stats
- document new `COINGECKO_API_BASE` setting
- add Telegram data model and resource
- provide example env variable for CoinGecko

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Could not resolve dependencies)*
- `npm --prefix frontend test -- --watchAll=false` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e794ffb60832aa14013bfe0136a80