### PR TITLE
Add fee breakdown for listings

### DIFF
--- a/frontend/src/components/TransactionCard.tsx
+++ b/frontend/src/components/TransactionCard.tsx
@@ -7,6 +7,7 @@ import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import Button from "@mui/material/Button";
 import "./TransactionCard.css";
+import { calculateFees } from "../utils/fees";
 
 interface TransactionCardProps {
   priceSol: string | null;
@@ -27,6 +28,9 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
 }) => {
   const { t } = useTranslation();
   const isMobile = useMediaQuery("(max-width:700px)");
+  const sellerAmount = priceSol
+    ? calculateFees(parseFloat(priceSol)).sellerReceives.toFixed(3)
+    : null;
 
   if (isMobile) {
     return (
@@ -37,7 +41,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
         >
           <CardContent className="transaction-card-mobile-content">
             <Typography sx={{ fontWeight: 700, right: 0 }} variant="subtitle2" color="text.secondary">
-              Total Price
+              {t('total_price')}
             </Typography>
             {priceSol ? (
               <Box display="flex" alignItems="baseline" gap={1}>
@@ -50,6 +54,11 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
                   </Typography>
                 )}
               </Box>
+              {sellerAmount && (
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                  {t('seller_receives')}: {sellerAmount} SOL
+                </Typography>
+              )}
             ) : (
               <Typography variant="h6">{t("market_no_price")}</Typography>
             )}
@@ -91,6 +100,11 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
         >
           {priceSol} SOL
           {priceUsd && <span className="usd"> (${priceUsd})</span>}
+          {sellerAmount && (
+            <span className="usd" style={{ display: 'block' }}>
+              {t('seller_receives')}: {sellerAmount} SOL
+            </span>
+          )}
         </span>
       ) : (
         <span

--- a/frontend/src/components/__tests__/TransactionCard.test.tsx
+++ b/frontend/src/components/__tests__/TransactionCard.test.tsx
@@ -21,6 +21,9 @@ describe("TransactionCard", () => {
       </I18nextProvider>,
     );
     expect(screen.getByText("1.23 SOL")).toBeTruthy();
+    expect(
+      screen.getByText(new RegExp(i18n.t('seller_receives')))
+    ).toBeTruthy();
     expect(screen.getByText(i18n.t("buy_now"))).toBeTruthy();
     fireEvent.click(screen.getByText(i18n.t("buy_now")));
     expect(onBuy).toHaveBeenCalled();

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -131,6 +131,8 @@
   "gallery_view_list": "List View",
   "earn_point": "Earn Point",
   "limit_reached": "Daily limit reached",
+  "total_price": "Total Price",
+  "seller_receives": "Seller Receives",
   "close": "Close",
   "buy_now": "Buy Now",
   "pay_with": "Pay with",

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -127,6 +127,8 @@
   "clear_filters": "Limpiar",
   "earn_point": "Ganar punto",
   "limit_reached": "Límite diario alcanzado",
+  "total_price": "Precio total",
+  "seller_receives": "Recibe el vendedor",
   "close": "Cerrar",
   "gallery_settings": "Ajustes de Galería",
   "gallery_view_grid9": "9 Tarjetas",

--- a/frontend/src/utils/__tests__/fees.test.ts
+++ b/frontend/src/utils/__tests__/fees.test.ts
@@ -1,0 +1,9 @@
+import { calculateFees } from '../fees';
+
+describe('calculateFees', () => {
+  test('computes fee breakdown', () => {
+    const res = calculateFees(0.08);
+    expect(res.totalFees).toBeCloseTo(0.0092);
+    expect(res.sellerReceives).toBeCloseTo(0.0708);
+  });
+});

--- a/frontend/src/utils/fees.ts
+++ b/frontend/src/utils/fees.ts
@@ -1,0 +1,26 @@
+export const FEE_MARKET_TAKER = 0.02;
+export const FEE_CREATOR_ROYALTY = 0.05;
+export const FEE_COMMUNITY = 0.03;
+export const FEE_OPERATIONS = 0.015;
+
+export const TOTAL_FEE_RATE =
+  FEE_MARKET_TAKER + FEE_CREATOR_ROYALTY + FEE_COMMUNITY + FEE_OPERATIONS;
+
+export interface FeeBreakdown {
+  marketTaker: number;
+  creatorRoyalty: number;
+  community: number;
+  operations: number;
+  totalFees: number;
+  sellerReceives: number;
+}
+
+export const calculateFees = (priceSol: number): FeeBreakdown => {
+  const marketTaker = priceSol * FEE_MARKET_TAKER;
+  const creatorRoyalty = priceSol * FEE_CREATOR_ROYALTY;
+  const community = priceSol * FEE_COMMUNITY;
+  const operations = priceSol * FEE_OPERATIONS;
+  const totalFees = marketTaker + creatorRoyalty + community + operations;
+  const sellerReceives = priceSol - totalFees;
+  return { marketTaker, creatorRoyalty, community, operations, totalFees, sellerReceives };
+};

--- a/mobile/locales/en.json
+++ b/mobile/locales/en.json
@@ -2,5 +2,7 @@
   "mobile_welcome": "Welcome to the Primos mobile app!",
   "render_started": "3D rendering started for Primo",
   "home": "Home",
-  "profile": "Profile"
+  "profile": "Profile",
+  "total_price": "Total Price",
+  "seller_receives": "Seller Receives"
 }

--- a/mobile/locales/es.json
+++ b/mobile/locales/es.json
@@ -2,5 +2,7 @@
   "mobile_welcome": "¡Bienvenido a la app móvil de Primos!",
   "render_started": "Renderizado 3D iniciado para Primo",
   "home": "Inicio",
-  "profile": "Perfil"
+  "profile": "Perfil",
+  "total_price": "Precio total",
+  "seller_receives": "Recibe el vendedor"
 }


### PR DESCRIPTION
## Summary
- compute Solana fee breakdown in new utility
- show seller net amount in TransactionCard
- translate new strings in English and Spanish
- add unit tests for fee calculations and updated TransactionCard

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e818dfdf4832ab6e2ed89c40a4fde