### PR TITLE
Show total price with breakdown

### DIFF
--- a/frontend/src/components/NFTCard.tsx
+++ b/frontend/src/components/NFTCard.tsx
@@ -50,8 +50,6 @@ const NFTCard: React.FC<NFTCardProps> = ({
     rankVariant = CARD_VARIANTS.find((v) => v.name === "silver");
   }
   const priceSol = nft.price ? nft.price.toFixed(3) : null;
-  const priceUsd =
-    nft.price && solPriceUsd ? (nft.price * solPriceUsd).toFixed(2) : null;
 
   return (
     <Dialog.Root open={open} onOpenChange={(val) => !val && onClose()}>
@@ -144,7 +142,7 @@ const NFTCard: React.FC<NFTCardProps> = ({
           >
             <TransactionCard
               priceSol={priceSol}
-              priceUsd={priceUsd}
+              solPriceUsd={solPriceUsd}
               onBuy={onBuy || onClose}
               variantBg={variant.bg}
               variantBorder={variant.border}

--- a/frontend/src/components/PriceBreakdown.css
+++ b/frontend/src/components/PriceBreakdown.css
@@ -1,0 +1,35 @@
+.price-summary {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: bold;
+}
+
+.price-summary .arrow {
+  transition: transform 0.2s;
+}
+
+.price-summary .arrow.open {
+  transform: rotate(180deg);
+}
+
+.price-breakdown .usd {
+  font-size: 0.92em;
+  color: #444;
+  font-weight: 500;
+  margin-left: 0.18em;
+  opacity: 0.85;
+}
+
+.price-breakdown .fee-details {
+  font-size: 0.8rem;
+  line-height: 1.1;
+  text-align: center;
+  margin-top: 0.3rem;
+  color: #444;
+}
+
+.price-breakdown .fee-details span {
+  display: block;
+}

--- a/frontend/src/components/PriceBreakdown.tsx
+++ b/frontend/src/components/PriceBreakdown.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useTranslation } from 'react-i18next';
+import { calculateFees } from '../utils/fees';
+import './PriceBreakdown.css';
+
+interface PriceBreakdownProps {
+  price: number;
+  solPriceUsd?: number | null;
+}
+
+const PriceBreakdown: React.FC<PriceBreakdownProps> = ({ price, solPriceUsd }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const fees = calculateFees(price);
+  const total = price + fees.totalFees;
+  const usd = solPriceUsd ? (total * solPriceUsd).toFixed(2) : null;
+
+  return (
+    <div className="price-breakdown">
+      <div
+        className="price-summary"
+        role="button"
+        onClick={() => setOpen(!open)}
+      >
+        {total.toFixed(3)} SOL
+        {usd && <span className="usd"> (${usd})</span>}
+        <ExpandMoreIcon
+          className={`arrow ${open ? 'open' : ''}`}
+          fontSize="small"
+          data-testid="expand-arrow"
+        />
+      </div>
+      {open && (
+        <div className="fee-details">
+          <span>{t('list_price')}: {price.toFixed(3)} SOL</span>
+          <span>{t('market_taker_fee')} (2%): {fees.marketTaker.toFixed(4)} SOL</span>
+          <span>{t('creator_royalty_fee')} (5%): {fees.creatorRoyalty.toFixed(4)} SOL</span>
+          <span>{t('community_fee')} (3%): {fees.community.toFixed(4)} SOL</span>
+          <span>{t('operations_fee')} (1.5%): {fees.operations.toFixed(4)} SOL</span>
+          <span>{t('seller_receives')}: {fees.sellerReceives.toFixed(3)} SOL</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PriceBreakdown;

--- a/frontend/src/components/TransactionCard.tsx
+++ b/frontend/src/components/TransactionCard.tsx
@@ -7,11 +7,11 @@ import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import Button from "@mui/material/Button";
 import "./TransactionCard.css";
-import { calculateFees } from "../utils/fees";
+import PriceBreakdown from "./PriceBreakdown";
 
 interface TransactionCardProps {
   priceSol: string | null;
-  priceUsd?: string | null;
+  solPriceUsd?: number;
   onBuy: () => void;
   variantBg: string;
   variantBorder: string;
@@ -20,7 +20,7 @@ interface TransactionCardProps {
 
 const TransactionCard: React.FC<TransactionCardProps> = ({
   priceSol,
-  priceUsd,
+  solPriceUsd,
   onBuy,
   variantBg,
   variantBorder,
@@ -28,11 +28,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
 }) => {
   const { t } = useTranslation();
   const isMobile = useMediaQuery("(max-width:700px)");
-  const feeDetails = priceSol ? calculateFees(parseFloat(priceSol)) : null;
-  const sellerAmount = feeDetails ? feeDetails.sellerReceives.toFixed(3) : null;
-  const totalPrice = feeDetails
-    ? (parseFloat(priceSol as string) + feeDetails.totalFees).toFixed(3)
-    : null;
+  const priceNum = priceSol ? parseFloat(priceSol) : null;
 
   if (isMobile) {
     return (
@@ -45,29 +41,8 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
             <Typography sx={{ fontWeight: 700, right: 0 }} variant="subtitle2" color="text.secondary">
               {t('total_price')}
             </Typography>
-            {priceSol ? (
-              <>
-                <Box display="flex" alignItems="baseline" gap={1}>
-                  <Typography sx={{ fontSize: '1rem', textAlign: 'right' }} variant="h5" fontWeight="bold">
-                    {totalPrice} SOL
-                  </Typography>
-                  {priceUsd && (
-                    <Typography sx={{ fontSize: '1rem', textAlign: 'right' }} variant="body2" color="text.secondary">
-                      (${priceUsd})
-                    </Typography>
-                  )}
-                </Box>
-                <div className="fee-details">
-                  <span>{t('list_price')}: {priceSol} SOL</span>
-                  <span>{t('market_taker_fee')} (2%): {feeDetails?.marketTaker.toFixed(4)} SOL</span>
-                  <span>{t('creator_royalty_fee')} (5%): {feeDetails?.creatorRoyalty.toFixed(4)} SOL</span>
-                  <span>{t('community_fee')} (3%): {feeDetails?.community.toFixed(4)} SOL</span>
-                  <span>{t('operations_fee')} (1.5%): {feeDetails?.operations.toFixed(4)} SOL</span>
-                  {sellerAmount && (
-                    <span>{t('seller_receives')}: {sellerAmount} SOL</span>
-                  )}
-                </div>
-              </>
+            {priceNum !== null ? (
+              <PriceBreakdown price={priceNum} solPriceUsd={solPriceUsd} />
             ) : (
               <Typography variant="h6">{t("market_no_price")}</Typography>
             )}
@@ -102,14 +77,8 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
 
   return (
     <div className="market-card-footer transaction-card-floating">
-      {priceSol ? (
-        <span
-          className="market-nft-price-pill"
-          style={{ background: variantBg, borderColor: variantBorder }}
-        >
-          {totalPrice} SOL
-          {priceUsd && <span className="usd"> (${priceUsd})</span>}
-        </span>
+      {priceNum !== null ? (
+        <PriceBreakdown price={priceNum} solPriceUsd={solPriceUsd} />
       ) : (
         <span
           className="market-nft-price-pill"
@@ -117,18 +86,6 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
         >
           {t("market_no_price")}
         </span>
-      )}
-      {priceSol && (
-        <div className="fee-details">
-          <span>{t('list_price')}: {priceSol} SOL</span>
-          <span>{t('market_taker_fee')} (2%): {feeDetails?.marketTaker.toFixed(4)} SOL</span>
-          <span>{t('creator_royalty_fee')} (5%): {feeDetails?.creatorRoyalty.toFixed(4)} SOL</span>
-          <span>{t('community_fee')} (3%): {feeDetails?.community.toFixed(4)} SOL</span>
-          <span>{t('operations_fee')} (1.5%): {feeDetails?.operations.toFixed(4)} SOL</span>
-          {sellerAmount && (
-            <span>{t('seller_receives')}: {sellerAmount} SOL</span>
-          )}
-        </div>
       )}
       <div className="transaction-card-buttons">
         <button

--- a/frontend/src/components/__tests__/TransactionCard.test.tsx
+++ b/frontend/src/components/__tests__/TransactionCard.test.tsx
@@ -13,7 +13,7 @@ describe("TransactionCard", () => {
       <I18nextProvider i18n={i18n}>
         <TransactionCard
           priceSol="1.23"
-          priceUsd="2.34"
+          solPriceUsd={2}
           onBuy={onBuy}
           variantBg="#fff"
           variantBorder="#000"
@@ -21,6 +21,8 @@ describe("TransactionCard", () => {
       </I18nextProvider>,
     );
     expect(screen.getByText("1.371 SOL")).toBeTruthy();
+    expect(screen.queryByText(new RegExp(i18n.t('list_price')))).toBeNull();
+    fireEvent.click(screen.getByTestId('expand-arrow'));
     expect(screen.getByText(new RegExp(i18n.t('list_price')))).toBeTruthy();
     expect(
       screen.getByText(new RegExp(i18n.t('seller_receives')))
@@ -35,6 +37,7 @@ describe("TransactionCard", () => {
       <I18nextProvider i18n={i18n}>
         <TransactionCard
           priceSol="1.23"
+          solPriceUsd={2}
           onBuy={() => {}}
           variantBg="#fff"
           variantBorder="#000"
@@ -50,6 +53,7 @@ describe("TransactionCard", () => {
       <I18nextProvider i18n={i18n}>
         <TransactionCard
           priceSol={null}
+          solPriceUsd={2}
           onBuy={() => {}}
           variantBg="#fff"
           variantBorder="#000"

--- a/frontend/src/pages/PrimosMarketGallery.tsx
+++ b/frontend/src/pages/PrimosMarketGallery.tsx
@@ -16,7 +16,7 @@ import FilterPanel from '../components/Filter';
 import { executeBuyNow } from '../utils/transaction';
 import MessageModal from '../components/MessageModal';
 import { AppMessage } from '../types';
-import { calculateFees } from '../utils/fees';
+import PriceBreakdown from '../components/PriceBreakdown';
 
 const MAGICEDEN_SYMBOL = 'primos';
 const PAGE_SIZE = 10;
@@ -220,9 +220,6 @@ const PrimosMarketGallery: React.FC = () => {
   const renderNft = (nft: MarketNFT) => {
     const variant = CARD_VARIANTS.find((v) => v.name === nft.variant) || CARD_VARIANTS[0];
     const priceSol = nft.price ? nft.price.toFixed(3) : null;
-    const priceUsd = nft.price && solPrice ? (nft.price * solPrice).toFixed(2) : null;
-    const feeDetails = nft.price ? calculateFees(nft.price) : null;
-    const totalPrice = feeDetails ? (nft.price + feeDetails.totalFees).toFixed(3) : priceSol;
 
     let rankVariant = CARD_VARIANTS.find(v => v.name === 'bronze');
     if (nft.rank !== null && nft.rank <= 100) {
@@ -287,19 +284,7 @@ const PrimosMarketGallery: React.FC = () => {
                   alignSelf: 'center',
                 }}
               >
-                {totalPrice} SOL
-                {priceUsd && (
-                  <span style={{ fontSize: '0.92em', color: '#444', fontWeight: 500, marginLeft: '0.18em', opacity: 0.85 }}>
-                    (${priceUsd})
-                  </span>
-                )}
-                <div className="fee-details">
-                  <span>{t('list_price')}: {priceSol} SOL</span>
-                  <span>{t('market_taker_fee')} (2%): {feeDetails?.marketTaker.toFixed(4)} SOL</span>
-                  <span>{t('creator_royalty_fee')} (5%): {feeDetails?.creatorRoyalty.toFixed(4)} SOL</span>
-                  <span>{t('community_fee')} (3%): {feeDetails?.community.toFixed(4)} SOL</span>
-                  <span>{t('operations_fee')} (1.5%): {feeDetails?.operations.toFixed(4)} SOL</span>
-                </div>
+                <PriceBreakdown price={nft.price} solPriceUsd={solPrice} />
               </Box>
             ) : (
               <Box


### PR DESCRIPTION
## Summary
- add PriceBreakdown component with dropdown of fees
- use component in TransactionCard and gallery
- update NFTCard and TransactionCard tests

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm test -- --watchAll=false` *(fails: several module errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f07842ad8832aabcb8a62519541ad