### PR TITLE
Fix Magic Eden pagination

### DIFF
--- a/frontend/src/utils/__tests__/magiceden.test.ts
+++ b/frontend/src/utils/__tests__/magiceden.test.ts
@@ -23,12 +23,12 @@ describe('magiceden utilities', () => {
     expect(data).toEqual({ totalSupply: 1 });
   });
 
-  test('fetchMagicEdenListings sorts by price', async () => {
-    const response = { ok: true, json: async () => ([{ price: 5 }, { price: 2 }]) };
+  test('fetchMagicEdenListings returns data as provided', async () => {
+    const listings = [{ price: 5 }, { price: 2 }];
+    const response = { ok: true, json: async () => listings };
     (global as any).fetch = jest.fn().mockResolvedValue(response);
     const list = await fetchMagicEdenListings('sym');
-    expect(list[0].price).toBe(2);
-    expect(list[1].price).toBe(5);
+    expect(list).toEqual(listings);
   });
 
   test('fetchMagicEdenActivity returns empty on error', async () => {

--- a/frontend/src/utils/magiceden.ts
+++ b/frontend/src/utils/magiceden.ts
@@ -134,7 +134,7 @@ export const getMagicEdenHolderStats = async (
  * @param symbol The collection symbol used by Magic Eden.
  * @param offset Pagination offset.
  * @param limit Maximum number of listings to return.
- * @returns Sorted list of listings or an empty array on failure.
+ * @returns List of listings or an empty array on failure.
  */
 export const fetchMagicEdenListings = async (
   symbol: string,
@@ -150,11 +150,8 @@ export const fetchMagicEdenListings = async (
     );
     if (!res.ok) return [];
     const data = await res.json();
-    const sorted = (data || []).sort(
-      (a: any, b: any) => (a.price ?? 0) - (b.price ?? 0)
-    );
-    setCached(key, sorted);
-    return sorted;
+    setCached(key, data);
+    return data;
   } catch (e) {
     console.error('Failed to fetch Magic Eden listings', e);
     return [];


### PR DESCRIPTION
## Summary
- preserve order of MagicEden listings to keep pagination working
- update tests for new ordering behavior

## Testing
- `npm ci` *(fails: ERESOLVE overriding peer dependency)*
- `npx craco test --watchAll=false` *(fails to run multiple frontend tests)*

------
https://chatgpt.com/codex/tasks/task_e_6880e585f360832a8172ed895173d32f