### PR TITLE
Add listing modal

### DIFF
--- a/frontend/src/components/ListItemModal.tsx
+++ b/frontend/src/components/ListItemModal.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, IconButton, ToggleButtonGroup, ToggleButton, TextField, InputAdornment, Select, MenuItem, ListItem, ListItemAvatar, Avatar, ListItemText, Box, Typography, Accordion, AccordionSummary, AccordionDetails, Button, Stack, Link } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { MarketNFT } from './NFTCard';
+import { calculateFees } from '../utils/fees';
+
+interface ListItemModalProps {
+  open: boolean;
+  nft: MarketNFT | null;
+  onClose: () => void;
+  onConfirm?: (price: number) => void;
+}
+
+const ListItemModal: React.FC<ListItemModalProps> = ({ open, nft, onClose, onConfirm }) => {
+  const [strategy, setStrategy] = useState('floor');
+  const [price, setPrice] = useState('');
+  const [currency, setCurrency] = useState('SOL');
+  if (!nft) return null;
+
+  const numericPrice = parseFloat(price) || 0;
+  const fees = numericPrice ? calculateFees(numericPrice) : null;
+  const buyerSees = fees ? (numericPrice + fees.totalFees).toFixed(3) : '';
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        List Items
+        <IconButton onClick={onClose} size="small"><CloseIcon /></IconButton>
+      </DialogTitle>
+      <DialogContent sx={{ px: 2, py: 3 }}>
+        <ToggleButtonGroup
+          fullWidth
+          exclusive
+          value={strategy}
+          onChange={(e, val) => val && setStrategy(val)}
+          sx={{ mb: 2 }}
+        >
+          <ToggleButton value="floor">Floor</ToggleButton>
+          <ToggleButton value="trait">Top Trait</ToggleButton>
+          <ToggleButton value="ladder">Ladder</ToggleButton>
+        </ToggleButtonGroup>
+        <TextField
+          fullWidth
+          label="Custom Global Price"
+          variant="outlined"
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          sx={{ mb: 2 }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <Select
+                  value={currency}
+                  onChange={(e) => setCurrency(e.target.value)}
+                  size="small"
+                >
+                  <MenuItem value="SOL">SOL</MenuItem>
+                </Select>
+              </InputAdornment>
+            ),
+          }}
+        />
+        <ListItem disableGutters sx={{ mb: 2 }}>
+          <ListItemAvatar>
+            <Avatar src={nft.image} />
+          </ListItemAvatar>
+          <ListItemText primary={nft.name} secondary="Unlisted" />
+          <Box>
+            <TextField
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              type="number"
+              size="small"
+            />
+            {buyerSees && (
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <Typography variant="caption" color="textSecondary">
+                    Buyer sees {buyerSees} {currency}
+                  </Typography>
+                </Tooltip.Trigger>
+                <Tooltip.Portal>
+                  <Tooltip.Content side="top" style={{ background: 'black', color: 'white', padding: '2px 6px', borderRadius: 4 }}>
+                    {buyerSees} {currency}
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              </Tooltip.Root>
+            )}
+          </Box>
+        </ListItem>
+        <Accordion>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography>You Receive</Typography>
+            <Typography sx={{ marginLeft: 'auto' }}>{fees ? fees.sellerReceives.toFixed(3) + ' ' + currency : '--'}</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography variant="body2" color="textSecondary">
+              Priority Fee: <Link component="button">Standard</Link>
+            </Typography>
+            {fees && (
+              <Typography variant="body2" color="success.main">
+                🍀 Earn up to an additional 0.003 SOL through Lucky Buy
+              </Typography>
+            )}
+          </AccordionDetails>
+        </Accordion>
+        <Stack direction="row" spacing={2} mt={2}>
+          <Button variant="outlined" fullWidth onClick={onClose}>Cancel</Button>
+          <Button variant="contained" color="secondary" fullWidth onClick={() => onConfirm && onConfirm(numericPrice)}>List 1 Item</Button>
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ListItemModal;

--- a/frontend/src/pages/NFTGallery.tsx
+++ b/frontend/src/pages/NFTGallery.tsx
@@ -11,6 +11,7 @@ import TraitStats from "../components/TraitStats";
 import NFTCard, { MarketNFT } from "../components/NFTCard";
 import api from '../utils/api';
 import MessageModal from '../components/MessageModal';
+import ListItemModal from '../components/ListItemModal';
 import { AppMessage } from '../types';
 import "./PrimosMarketGallery.css";
 import * as Dialog from "@radix-ui/react-dialog";
@@ -38,6 +39,7 @@ const NFTGallery: React.FC = () => {
   const [floorPrice, setFloorPrice] = useState<number | null>(null);
   const [selectedNft, setSelectedNft] = useState<MarketNFT | null>(null);
   const [cardOpen, setCardOpen] = useState(false);
+  const [listOpen, setListOpen] = useState(false);
   const [statuses, setStatuses] = useState<Record<string, { stlUrl?: string }>>({});
   const { t } = useTranslation();
   const [message, setMessage] = useState<AppMessage | null>(null);
@@ -45,7 +47,7 @@ const NFTGallery: React.FC = () => {
   const handleList = (nft: MarketNFT) => {
     setSelectedNft(nft);
     setCardOpen(false);
-    setMessage({ text: t('coming_soon') });
+    setListOpen(true);
   };
 
 
@@ -360,6 +362,15 @@ const NFTGallery: React.FC = () => {
       </div>
       <TraitStats nftIds={nfts.map((n) => n.id)} />
     </div>
+    <ListItemModal
+      open={listOpen}
+      nft={selectedNft}
+      onClose={() => setListOpen(false)}
+      onConfirm={() => {
+        setListOpen(false);
+        setMessage({ text: t('coming_soon') });
+      }}
+    />
     <MessageModal
       open={!!message}
       message={message}


### PR DESCRIPTION
## Summary
- create `ListItemModal` component for listing NFTs
- open the modal from NFTGallery when listing NFTs

## Testing
- `node node_modules/@craco/craco/dist/bin/craco.js build` *(fails: Can't resolve '@mui/icons-material/Notifications')*
- `node node_modules/@craco/craco/dist/bin/craco.js test --silent -- -u` *(fails to run tests due to Jest parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880e8c8467c832aa7337b51d099dd2a