### PR TITLE
Compute 24h volume from DB transactions

### DIFF
--- a/backend/src/main/java/com/primos/model/Transaction.java
+++ b/backend/src/main/java/com/primos/model/Transaction.java
@@ -15,6 +15,7 @@ public class Transaction extends PanacheMongoEntity {
     private String source;
     private String timestamp;
     private String status;
+    private Double solSpent;
 
     /**
      * Expose the MongoDB generated identifier so tests can verify the
@@ -95,5 +96,13 @@ public class Transaction extends PanacheMongoEntity {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public Double getSolSpent() {
+        return solSpent;
+    }
+
+    public void setSolSpent(Double solSpent) {
+        this.solSpent = solSpent;
     }
 }

--- a/backend/src/main/java/com/primos/resource/TransactionResource.java
+++ b/backend/src/main/java/com/primos/resource/TransactionResource.java
@@ -8,6 +8,10 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.DefaultValue;
+import java.util.List;
 
 @Path("/api/transactions")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -20,5 +24,19 @@ public class TransactionResource {
     public Response recordTx(TransactionDTO tx) {
         service.recordTransaction(tx);
         return Response.status(Response.Status.CREATED).build();
+    }
+
+    @GET
+    @Path("/recent")
+    public List<com.primos.model.Transaction> recent(@QueryParam("hours") @DefaultValue("24") int hours) {
+        return service.recentTransactions(hours);
+    }
+
+    @GET
+    @Path("/volume24h")
+    public Response volume24h() {
+        double vol = service.volumeLast24h();
+        var json = jakarta.json.Json.createObjectBuilder().add("volume", vol).build();
+        return Response.ok(json).build();
     }
 }

--- a/backend/src/test/java/com/primos/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TransactionServiceTest.java
@@ -19,7 +19,26 @@ public class TransactionServiceTest {
         Transaction tx = svc.recordTransaction(dto);
         assertNotNull(tx.getId());
         assertEquals("abc123", tx.getTxId());
+        assertNull(tx.getSolSpent());
         Transaction stored = Transaction.find("txId", "abc123").firstResult();
         assertNotNull(stored);
+    }
+
+    @Test
+    public void testVolumeLast24h() {
+        TransactionService svc = new TransactionService();
+        Transaction t = new Transaction();
+        t.setTxId("txv1");
+        t.setBuyer("b");
+        t.setMint("m");
+        t.setCollection("c");
+        t.setSource("s");
+        t.setTimestamp(java.time.Instant.now().toString());
+        t.setStatus("confirmed");
+        t.setPrice(1e9);
+        t.setSolSpent(1e9);
+        t.persist();
+        double vol = svc.volumeLast24h();
+        assertEquals(1e9, vol);
     }
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import hero from '../images/primoslogo.png';
 import { getMagicEdenStats, getMagicEdenHolderStats } from '../utils/magiceden';
 import { getPythSolPrice } from '../utils/pyth';
 import api from '../utils/api';
+import { fetchVolume24h } from '../utils/transaction';
 import Avatar from '@mui/material/Avatar';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
@@ -39,10 +40,11 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
   useEffect(() => {
     async function fetchStats() {
       try {
-        const [meStats, meHolderStats, solPrice] = await Promise.all([
+        const [meStats, meHolderStats, solPrice, dbVolume] = await Promise.all([
           getMagicEdenStats(MAGICEDEN_SYMBOL),
           getMagicEdenHolderStats(MAGICEDEN_SYMBOL),
           getPythSolPrice(),
+          fetchVolume24h(),
         ]);
         const floor = meStats?.floorPrice ?? null;
         const supply = meHolderStats?.totalSupply ?? null;
@@ -51,7 +53,7 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
         setStats({
           uniqueHolders: meHolderStats?.uniqueHolders ?? null,
           totalSupply: supply,
-          volume24hr: meStats?.volume24hr ?? null,
+          volume24hr: dbVolume ?? meStats?.volume24hr ?? null,
           listedCount: meStats?.listedCount ?? null,
           floorPrice: floor,
           solPrice: solPrice ?? null,

--- a/frontend/src/utils/transaction.ts
+++ b/frontend/src/utils/transaction.ts
@@ -20,6 +20,35 @@ export const recordTransaction = async (tx: TxRecord) => {
   }
 };
 
+export interface DbTransaction {
+  txId: string;
+  buyer: string;
+  seller?: string;
+  mint: string;
+  price?: number;
+  collection: string;
+  source: string;
+  timestamp: string;
+  status: string;
+  solSpent?: number;
+}
+
+export const fetchRecentTransactions = async (
+  hours = 24
+): Promise<DbTransaction[]> => {
+  const res = await api.get<DbTransaction[]>(`/api/transactions/recent?hours=${hours}`);
+  return res.data;
+};
+
+export const fetchVolume24h = async (): Promise<number> => {
+  try {
+    const res = await api.get<{ volume: number }>('/api/transactions/volume24h');
+    return res.data.volume;
+  } catch {
+    return 0;
+  }
+};
+
 export interface BuyNowListing {
   tokenMint: string;
   tokenAta: string;


### PR DESCRIPTION
## Summary
- track SOL spent in `Transaction`
- compute 24h volume and list recent transactions in `TransactionService`
- expose `/api/transactions/recent` and `/api/transactions/volume24h`
- fetch DB volume on the home page
- add TypeScript helpers for recent transactions and volume
- update unit tests

## Testing
- `npm --prefix frontend test --silent` *(fails: craco not found)*
- `mvn -q -f backend/pom.xml test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68824cbd423c832a9ba77074406b166c