### PR TITLE
Fix dialog accessibility and add modal titles

### DIFF
--- a/frontend/src/components/MessageModal.tsx
+++ b/frontend/src/components/MessageModal.tsx
@@ -20,7 +20,12 @@ const MessageModal: React.FC<MessageModalProps> = ({ open, message, onClose, onC
     <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
       <Dialog.Overlay className="dialog-overlay" />
       <Dialog.Content className="dialog-content">
-        <p>{message.text}</p>
+        <Dialog.Title className="dialog-title">
+          {t('message_modal_title')}
+        </Dialog.Title>
+        <Dialog.Description asChild>
+          <p>{message.text}</p>
+        </Dialog.Description>
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginTop: '1rem' }}>
           {onConfirm && (
             <Button variant="contained" onClick={onConfirm}>

--- a/frontend/src/components/NFTCard.tsx
+++ b/frontend/src/components/NFTCard.tsx
@@ -55,6 +55,7 @@ const NFTCard: React.FC<NFTCardProps> = ({
     <Dialog.Root open={open} onOpenChange={(val) => !val && onClose()}>
       <Dialog.Overlay className="nft-dialog-overlay" />
       <Dialog.Content className="nft-dialog-content">
+        <Dialog.Title className="dialog-title">{nft.name}</Dialog.Title>
         <button
           className="close-button"
           onClick={onClose}
@@ -62,17 +63,18 @@ const NFTCard: React.FC<NFTCardProps> = ({
         >
           <CloseIcon fontSize="medium" />
         </button>
-        <Box
-          className="nft-modal-vertical"
-          sx={{
-            display: { xs: "block", md: "flex" },
-            flexDirection: { md: "row" },
-            alignItems: { md: "flex-start" },
-            gap: { md: 3 },
-            width: "100%",
-            maxWidth: "100%",
-          }}
-        >
+        <Dialog.Description asChild>
+          <Box
+            className="nft-modal-vertical"
+            sx={{
+              display: { xs: "block", md: "flex" },
+              flexDirection: { md: "row" },
+              alignItems: { md: "flex-start" },
+              gap: { md: 3 },
+              width: "100%",
+              maxWidth: "100%",
+            }}
+          >
           <Box
             className="nft-modal-image-container"
             sx={{
@@ -150,6 +152,7 @@ const NFTCard: React.FC<NFTCardProps> = ({
             />
           </Box>
         </Box>
+        </Dialog.Description>
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/frontend/src/components/TelegramPanel.tsx
+++ b/frontend/src/components/TelegramPanel.tsx
@@ -93,6 +93,7 @@ const TelegramPanel: React.FC<TelegramPanelProps> = ({ contract, open, onClose }
       {error && <Typography color="error" variant="body2">{error}</Typography>}
       <Dialog.Overlay className="telegram-overlay" />
       <Dialog.Content className="telegram-content">
+        <Dialog.Title className="dialog-title">{t('telegram_data')}</Dialog.Title>
         <IconButton
           className="telegram-close"
           onClick={onClose}
@@ -101,17 +102,17 @@ const TelegramPanel: React.FC<TelegramPanelProps> = ({ contract, open, onClose }
         >
           <CloseIcon fontSize="small" />
         </IconButton>
-        <Typography variant="h6" sx={{ mb: 1 }}>
-        </Typography>
-        <Box className="telegram-list" sx={{ maxHeight: 400, overflowY: 'auto', mt: 1 }}>
-          {entries.map((e) => (
-            <Box key={e.id} sx={{ mb: 2, whiteSpace: 'pre-wrap' }}>
-              <Typography variant="body2" component="div">
-                {e.message}
-              </Typography>
-            </Box>
-          ))}
-        </Box>
+        <Dialog.Description asChild>
+          <Box className="telegram-list" sx={{ maxHeight: 400, overflowY: 'auto', mt: 1 }}>
+            {entries.map((e) => (
+              <Box key={e.id} sx={{ mb: 2, whiteSpace: 'pre-wrap' }}>
+                <Typography variant="body2" component="div">
+                  {e.message}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Dialog.Description>
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/frontend/src/components/TxProgressModal.css
+++ b/frontend/src/components/TxProgressModal.css
@@ -18,6 +18,10 @@
   text-align: center;
 }
 
+.tx-modal-title {
+  margin-bottom: 0.5rem;
+}
+
 .tx-modal-spinner {
   width: 40px;
   height: 40px;

--- a/frontend/src/components/TxProgressModal.tsx
+++ b/frontend/src/components/TxProgressModal.tsx
@@ -21,8 +21,13 @@ const TxProgressModal: React.FC<TxProgressModalProps> = ({ open, step }) => {
     <Dialog.Root open={open}>
       <Dialog.Overlay className="tx-modal-overlay" />
       <Dialog.Content className="tx-modal-content">
+        <Dialog.Title className="tx-modal-title">
+          {t('tx_progress_title')}
+        </Dialog.Title>
         <div className="tx-modal-spinner" />
-        <pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{messages[step]}</pre>
+        <Dialog.Description asChild>
+          <pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{messages[step]}</pre>
+        </Dialog.Description>
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -190,6 +190,8 @@
   "has_3d": "3D available",
   "tx_success": "Transaction sent!",
   "tx_failed": "Transaction failed",
+  "tx_progress_title": "Transaction Progress",
+  "message_modal_title": "Message",
   "tx_step_init": "Step 1 - Initializing Buy Transaction...",
   "tx_step_sign": "Step 2 - Signing Buy Transaction\nReview and confirm in your wallet...",
   "tx_step_confirm": "Step 3 - Confirming Buy Transaction...",

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -190,6 +190,8 @@
   "has_3d": "3D disponible",
   "tx_success": "¡Transacción enviada!",
   "tx_failed": "Transacción fallida",
+  "tx_progress_title": "Progreso de la transacción",
+  "message_modal_title": "Mensaje",
   "tx_step_init": "Paso 1 - Inicializando compra...",
   "tx_step_sign": "Paso 2 - Firmando compra\nRevisa y confirma en tu wallet...",
   "tx_step_confirm": "Paso 3 - Confirmando compra...",


### PR DESCRIPTION
## Summary
- add dialog titles/descriptions for transaction progress and messages
- include titles for NFT cards and telegram panel dialogs
- localize new dialog titles
- style tx progress modal title

## Testing
- `npm test --silent` *(fails: Cannot read properties of undefined (reading 'then'))*

------
https://chatgpt.com/codex/tasks/task_e_68826b98763c832a82eef84c77b522c7