### PR TITLE
feat: add NFT fetch loading indicators

### DIFF
--- a/frontend/src/pages/Experiment1.tsx
+++ b/frontend/src/pages/Experiment1.tsx
@@ -8,6 +8,7 @@ import { fetchCollectionNFTsForOwner, HeliusNFT } from '../utils/helius';
 import api from '../utils/api';
 import MessageModal from '../components/MessageModal';
 import { AppMessage } from '../types';
+import LoadingOverlay from '../components/LoadingOverlay';
 import './Experiment1.css';
 
 const PRIMO_COLLECTION = process.env.REACT_APP_PRIMOS_COLLECTION!;
@@ -35,15 +36,21 @@ const Experiment1: React.FC = () => {
   const [statuses, setStatuses] = useState<Record<string, StatusInfo>>({});
   const [message, setMessage] = useState<AppMessage | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const fetchNfts = async () => {
       if (!wallet.publicKey) return;
-      const items = await fetchCollectionNFTsForOwner(
-        wallet.publicKey.toBase58(),
-        PRIMO_COLLECTION
-      );
-      setNfts(items);
+      setLoading(true);
+      try {
+        const items = await fetchCollectionNFTsForOwner(
+          wallet.publicKey.toBase58(),
+          PRIMO_COLLECTION
+        );
+        setNfts(items);
+      } finally {
+        setLoading(false);
+      }
     };
     fetchNfts();
   }, [wallet.publicKey]);
@@ -97,6 +104,7 @@ const Experiment1: React.FC = () => {
 
   return (
     <Box className="experiment-container">
+      {loading && <LoadingOverlay message={t('loading_nfts')} />}
       <Typography variant="h4" sx={{ mb: 2 }}>
         {t('experiment1_title')}
       </Typography>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -12,6 +12,7 @@ import { fetchVolume24h } from '../utils/transaction';
 import Avatar from '@mui/material/Avatar';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
+import LoadingOverlay from '../components/LoadingOverlay';
 
 interface Stats {
   uniqueHolders: number | null;
@@ -38,6 +39,7 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
   const [members, setMembers] = useState<DaoMember[]>([]);
   const wallet = useWallet();
   const isConnected = connected ?? wallet.connected;
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     async function fetchStats() {
@@ -74,6 +76,7 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
   useEffect(() => {
     const fetchMembers = async () => {
       try {
+        setLoading(true);
         const res = await api.get<DaoMember[]>('/api/user/primos');
         const enriched = await Promise.all(
           res.data.slice(0, 5).map(async (m) => {
@@ -91,6 +94,8 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
         setMembers(enriched);
       } catch {
         setMembers([]);
+      } finally {
+        setLoading(false);
       }
     };
     fetchMembers();
@@ -107,6 +112,7 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
         py: 6,
       }}
     >
+      {loading && <LoadingOverlay message={t('loading_nfts')} />}
       <Box
       >
         {!isConnected && (

--- a/frontend/src/pages/Primos.tsx
+++ b/frontend/src/pages/Primos.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
 import { getPrimaryDomainName } from '../utils/sns';
 import './Primos.css';
+import LoadingOverlay from '../components/LoadingOverlay';
 
 const PRIMO_COLLECTION = process.env.REACT_APP_PRIMOS_COLLECTION!;
 
@@ -26,10 +27,12 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
   const { t } = useTranslation();
   const [members, setMembers] = useState<Member[]>([]);
   const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     async function fetchMembers() {
       try {
+        setLoading(true);
         const res = await api.get<Member[]>('/api/user/primos');
         const sorted = res.data.slice().sort((a: Member, b: Member) => b.pesos - a.pesos);
         const enriched = await Promise.all(
@@ -50,6 +53,8 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
         setMembers(enriched);
       } catch {
         setMembers([]);
+      } finally {
+        setLoading(false);
       }
     }
     fetchMembers();
@@ -62,6 +67,7 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
 
   return (
     <Box className="primos-container">
+      {loading && <LoadingOverlay message={t('loading_nfts')} />}
       <Typography variant="h4" className="primos-title">
         {t('primos_title')}
       </Typography>

--- a/frontend/src/pages/Stickers.tsx
+++ b/frontend/src/pages/Stickers.tsx
@@ -8,6 +8,7 @@ import { fetchCollectionNFTsForOwner, HeliusNFT } from '../utils/helius';
 import MessageModal from '../components/MessageModal';
 import { AppMessage } from '../types';
 import './Stickers.css';
+import LoadingOverlay from '../components/LoadingOverlay';
 
 const PRIMO_COLLECTION = process.env.REACT_APP_PRIMOS_COLLECTION!;
 
@@ -17,15 +18,21 @@ const Stickers: React.FC = () => {
   const [nfts, setNfts] = useState<HeliusNFT[]>([]);
   const [selected, setSelected] = useState<HeliusNFT | null>(null);
   const [message, setMessage] = useState<AppMessage | null>(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const fetchNfts = async () => {
       if (!wallet.publicKey) return;
-      const items = await fetchCollectionNFTsForOwner(
-        wallet.publicKey.toBase58(),
-        PRIMO_COLLECTION
-      );
-      setNfts(items);
+      setLoading(true);
+      try {
+        const items = await fetchCollectionNFTsForOwner(
+          wallet.publicKey.toBase58(),
+          PRIMO_COLLECTION
+        );
+        setNfts(items);
+      } finally {
+        setLoading(false);
+      }
     };
     fetchNfts();
   }, [wallet.publicKey]);
@@ -37,6 +44,7 @@ const Stickers: React.FC = () => {
 
   return (
     <Box className="experiment-container">
+      {loading && <LoadingOverlay message={t('loading_nfts')} />}
       <Typography variant="h4" sx={{ mb: 2 }}>
         {t('experiment2_title')}
       </Typography>

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -19,6 +19,7 @@ import BetaRedeem from '../components/BetaRedeem';
 import { Notification, AppMessage } from '../types';
 import MessageModal from '../components/MessageModal';
 import { verifyDomainOwnership, getPrimaryDomainName } from '../utils/sns';
+import LoadingOverlay from '../components/LoadingOverlay';
 
 type SocialLinks = {
   twitter: string;
@@ -89,6 +90,7 @@ const UserProfile: React.FC = () => {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [primaryDomain, setPrimaryDomain] = useState<string | null>(null);
   const [message, setMessage] = useState<AppMessage | null>(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (profileKey) {
@@ -122,9 +124,11 @@ const UserProfile: React.FC = () => {
 
   useEffect(() => {
     if (profileKey) {
+      setLoading(true);
       getAssetsByCollection(PRIMO_COLLECTION, profileKey)
         .then(setNfts)
-        .catch(() => setNfts([]));
+        .catch(() => setNfts([]))
+        .finally(() => setLoading(false));
     }
   }, [profileKey]);
 
@@ -287,6 +291,7 @@ const fadeOut = keyframes`
 
   return (
     <>
+      {loading && <LoadingOverlay message={t('loading_nfts')} />}
       <Box className="user-profile">
         {pfpImage && (
           <Box display="flex" justifyContent="center" mb={2}>

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,21 @@
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+// @ts-ignore
+if (typeof global.TextEncoder === 'undefined') {
+  // @ts-ignore
+  global.TextEncoder = TextEncoder;
+}
+// @ts-ignore
+if (typeof global.TextDecoder === 'undefined') {
+  // @ts-ignore
+  global.TextDecoder = TextDecoder as unknown as typeof global.TextDecoder;
+}
+
+jest.mock('@solana/wallet-adapter-react', () => ({
+  useWallet: () => ({ publicKey: null, connected: false })
+}));
+
+jest.mock('./utils/sns', () => ({
+  verifyDomainOwnership: jest.fn(async () => false),
+  getPrimaryDomainName: jest.fn(async () => null)
+}));


### PR DESCRIPTION
## Summary
- show loading overlays while fetching NFTs across pages
- configure jest with TextEncoder polyfill and wallet/SNS mocks

## Testing
- `CI=true npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688d97350404832a8b3eac9c063628e8