### PR TITLE
feat: show loading icons while fetching NFTs

### DIFF
--- a/frontend/src/components/Loading.css
+++ b/frontend/src/components/Loading.css
@@ -1,0 +1,23 @@
+.loading-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 0;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #000;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 0.5rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import './Loading.css';
+
+interface LoadingProps {
+  message?: string;
+}
+
+const Loading: React.FC<LoadingProps> = ({ message }) => (
+  <div className="loading-wrapper">
+    <div className="spinner" />
+    {message && <span>{message}</span>}
+  </div>
+);
+
+export default Loading;

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -25,6 +25,7 @@ import * as Tabs from '@radix-ui/react-tabs';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
 import { getMagicEdenStats } from '../utils/magiceden';
 import { getPythSolPrice } from '../utils/pyth';
+import Loading from '../components/Loading';
 
 const ADMIN_WALLET =
   process.env.REACT_APP_ADMIN_WALLET ?? 'EB5uzfZZrWQ8BPEmMNrgrNMNCHR1qprrsspHNNgVEZa6';
@@ -71,6 +72,7 @@ const Admin: React.FC = () => {
   const [filter, setFilter] = useState<'active' | 'inactive'>('active');
   const [members, setMembers] = useState<AdminMember[]>([]);
   const [search, setSearch] = useState('');
+  const [loadingMembers, setLoadingMembers] = useState(true);
 
   useEffect(() => {
     if (publicKey?.toBase58() === ADMIN_WALLET) {
@@ -93,6 +95,7 @@ const Admin: React.FC = () => {
     if (publicKey?.toBase58() !== ADMIN_WALLET) return;
 
     async function fetchMembers() {
+      setLoadingMembers(true);
       try {
         if (!publicKey) return;
         const res = await api.get<Member[]>("/api/user/primos", {
@@ -141,6 +144,8 @@ const Admin: React.FC = () => {
         setMembers(enriched);
       } catch {
         setMembers([]);
+      } finally {
+        setLoadingMembers(false);
       }
     }
 
@@ -158,6 +163,10 @@ const Admin: React.FC = () => {
 
   if (publicKey?.toBase58() !== ADMIN_WALLET) {
     return <Typography>{t('access_denied')}</Typography>;
+  }
+
+  if (loadingMembers) {
+    return <Loading message={t('loading_nfts')} />;
   }
 
   const filtered = members.filter((m) =>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -12,6 +12,7 @@ import { fetchVolume24h } from '../utils/transaction';
 import Avatar from '@mui/material/Avatar';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
+import Loading from '../components/Loading';
 
 interface Stats {
   uniqueHolders: number | null;
@@ -36,6 +37,7 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
   const { t } = useTranslation();
   const [stats, setStats] = useState<Stats | null>(null);
   const [members, setMembers] = useState<DaoMember[]>([]);
+  const [loadingMembers, setLoadingMembers] = useState(true);
   const wallet = useWallet();
   const isConnected = connected ?? wallet.connected;
 
@@ -73,6 +75,7 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
 
   useEffect(() => {
     const fetchMembers = async () => {
+      setLoadingMembers(true);
       try {
         const res = await api.get<DaoMember[]>('/api/user/primos');
         const enriched = await Promise.all(
@@ -91,6 +94,8 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
         setMembers(enriched);
       } catch {
         setMembers([]);
+      } finally {
+        setLoadingMembers(false);
       }
     };
     fetchMembers();
@@ -243,7 +248,10 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
         border: '2px solid #fff',
         position: 'relative',
       }}>
-        {members.length > 0 && (
+        {loadingMembers ? (
+          <Loading message={t('loading_nfts')} />
+        ) : (
+          members.length > 0 && (
             <Box>
               <Typography variant="subtitle1" sx={{ color: '#aaa' }}>
                 {t('primos_title')}
@@ -258,7 +266,8 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
                 ))}
               </Box>
             </Box>
-          )}
+          )
+        )}
       </Box>
       <Box sx={{
         mt: 6,

--- a/frontend/src/pages/Primos.tsx
+++ b/frontend/src/pages/Primos.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
 import { getPrimaryDomainName } from '../utils/sns';
 import './Primos.css';
+import Loading from '../components/Loading';
 
 const PRIMO_COLLECTION = process.env.REACT_APP_PRIMOS_COLLECTION!;
 
@@ -26,9 +27,11 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
   const { t } = useTranslation();
   const [members, setMembers] = useState<Member[]>([]);
   const [search, setSearch] = useState('');
+  const [loadingMembers, setLoadingMembers] = useState(true);
 
   useEffect(() => {
     async function fetchMembers() {
+      setLoadingMembers(true);
       try {
         const res = await api.get<Member[]>('/api/user/primos');
         const sorted = res.data.slice().sort((a: Member, b: Member) => b.pesos - a.pesos);
@@ -50,6 +53,8 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
         setMembers(enriched);
       } catch {
         setMembers([]);
+      } finally {
+        setLoadingMembers(false);
       }
     }
     fetchMembers();
@@ -73,33 +78,39 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
         margin="normal"
       />
       <Box className="primos-list">
-        {filtered.map((m) => (
-          <Link
-            key={m.publicKey}
-            to={`/user/${m.publicKey}`}
-            style={{ textDecoration: 'none', color: 'inherit' }}
-          >
-            <Box className="primos-card">
-              <Avatar
-                src={m.pfp || undefined}
-                sx={{ width: 56, height: 56 }}
-              />
-              <Box ml={1}>
-                <Typography>
-                  {(m.domain ? m.domain + ' ' : '') + m.publicKey.slice(0, 4) + '...' + m.publicKey.slice(-3)}
-                </Typography>
-                <Box className="primos-pills">
-                  <span className="primos-pill">{t('points')}: {m.points}</span>
-                  <span className="primos-pill">{t('pesos')}: {m.pesos}</span>
+        {loadingMembers ? (
+          <Loading message={t('loading_nfts')} />
+        ) : (
+          <>
+            {filtered.map((m) => (
+              <Link
+                key={m.publicKey}
+                to={`/user/${m.publicKey}`}
+                style={{ textDecoration: 'none', color: 'inherit' }}
+              >
+                <Box className="primos-card">
+                  <Avatar
+                    src={m.pfp || undefined}
+                    sx={{ width: 56, height: 56 }}
+                  />
+                  <Box ml={1}>
+                    <Typography>
+                      {(m.domain ? m.domain + ' ' : '') + m.publicKey.slice(0, 4) + '...' + m.publicKey.slice(-3)}
+                    </Typography>
+                    <Box className="primos-pills">
+                      <span className="primos-pill">{t('points')}: {m.points}</span>
+                      <span className="primos-pill">{t('pesos')}: {m.pesos}</span>
+                    </Box>
+                  </Box>
                 </Box>
-              </Box>
-            </Box>
-          </Link>
-        ))}
-        {filtered.length === 0 && (
-          <Typography className="no-members">
-            {t('primos_no_members')}
-          </Typography>
+              </Link>
+            ))}
+            {filtered.length === 0 && (
+              <Typography className="no-members">
+                {t('primos_no_members')}
+              </Typography>
+            )}
+          </>
         )}
       </Box>
     </Box>

--- a/frontend/src/pages/Stickers.tsx
+++ b/frontend/src/pages/Stickers.tsx
@@ -8,6 +8,7 @@ import { fetchCollectionNFTsForOwner, HeliusNFT } from '../utils/helius';
 import MessageModal from '../components/MessageModal';
 import { AppMessage } from '../types';
 import './Stickers.css';
+import Loading from '../components/Loading';
 
 const PRIMO_COLLECTION = process.env.REACT_APP_PRIMOS_COLLECTION!;
 
@@ -17,15 +18,21 @@ const Stickers: React.FC = () => {
   const [nfts, setNfts] = useState<HeliusNFT[]>([]);
   const [selected, setSelected] = useState<HeliusNFT | null>(null);
   const [message, setMessage] = useState<AppMessage | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchNfts = async () => {
       if (!wallet.publicKey) return;
-      const items = await fetchCollectionNFTsForOwner(
-        wallet.publicKey.toBase58(),
-        PRIMO_COLLECTION
-      );
-      setNfts(items);
+      setLoading(true);
+      try {
+        const items = await fetchCollectionNFTsForOwner(
+          wallet.publicKey.toBase58(),
+          PRIMO_COLLECTION
+        );
+        setNfts(items);
+      } finally {
+        setLoading(false);
+      }
     };
     fetchNfts();
   }, [wallet.publicKey]);
@@ -43,21 +50,25 @@ const Stickers: React.FC = () => {
       <Typography variant="body1" sx={{ mb: 2 }}>
         {t('experiment2_desc')}
       </Typography>
-      <Box className="nft-grid">
-        {nfts.map((nft) => (
-          <div
-            key={nft.id}
-            className="nft-wrapper"
-            onClick={() => setSelected(nft)}
-          >
-            <img
-              src={nft.image}
-              alt={nft.name}
-              className={selected?.id === nft.id ? 'nft selected' : 'nft'}
-            />
-          </div>
-        ))}
-      </Box>
+      {loading ? (
+        <Loading message={t('loading_nfts')} />
+      ) : (
+        <Box className="nft-grid">
+          {nfts.map((nft) => (
+            <div
+              key={nft.id}
+              className="nft-wrapper"
+              onClick={() => setSelected(nft)}
+            >
+              <img
+                src={nft.image}
+                alt={nft.name}
+                className={selected?.id === nft.id ? 'nft selected' : 'nft'}
+              />
+            </div>
+          ))}
+        </Box>
+      )}
       <Button variant="contained" sx={{ mt: 2 }} disabled={!selected} onClick={handleOrder}>
         {t('order_sticker')}
       </Button>

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -18,6 +18,7 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 import { Link, useParams } from 'react-router-dom';
 import BetaRedeem from '../components/BetaRedeem';
 import { Notification, AppMessage } from '../types';
+import Loading from '../components/Loading';
 import MessageModal from '../components/MessageModal';
 import { verifyDomainOwnership, getPrimaryDomainName } from '../utils/sns';
 
@@ -91,6 +92,7 @@ const UserProfile: React.FC = () => {
   const [primaryDomain, setPrimaryDomain] = useState<string | null>(null);
   const [message, setMessage] = useState<AppMessage | null>(null);
   const [notifDialogOpen, setNotifDialogOpen] = useState(false);
+  const [loadingNfts, setLoadingNfts] = useState(true);
 
   useEffect(() => {
     if (profileKey) {
@@ -124,9 +126,11 @@ const UserProfile: React.FC = () => {
 
   useEffect(() => {
     if (profileKey) {
+      setLoadingNfts(true);
       getAssetsByCollection(PRIMO_COLLECTION, profileKey)
         .then(setNfts)
-        .catch(() => setNfts([]));
+        .catch(() => setNfts([]))
+        .finally(() => setLoadingNfts(false));
     }
   }, [profileKey]);
 
@@ -348,8 +352,11 @@ const fadeOut = keyframes`
           </Button>
         )}
         {isOwner && showNFTs && (
-          <Box className="profile-nft-grid">
-            {nfts.map((nft, i) => {
+          loadingNfts ? (
+            <Loading message={t('loading_nfts')} />
+          ) : (
+            <Box className="profile-nft-grid">
+              {nfts.map((nft, i) => {
               const isSelected = user.pfp.replace(/"/g, '') === nft.id;
               return (
                 <button
@@ -363,11 +370,12 @@ const fadeOut = keyframes`
                   <img src={nft.image} alt={nft.name} />
                   {isSelected && (
                     <span className="selected-overlay">{t('selected')}</span>
-                  )}
+                )}
                 </button>
               );
             })}
-          </Box>
+            </Box>
+          )
         )}
         {isOwner && isEditing ? (
           <TextField
@@ -499,27 +507,31 @@ const fadeOut = keyframes`
           <Typography className="nfts-title" variant="h6">
             Primo NFTs
           </Typography>
-          <Box className="profile-nft-grid">
-            {nfts.map((nft) => (
-              <Box key={nft.id} className="owned-nft-thumb">
-                <img src={nft.image} alt={nft.name} />
-                <Box className="like-row">
-                  <Typography sx={{ fontSize: '0.8rem' }}>
-                    {likes[nft.id]?.count ?? 0}
-                  </Typography>
-                  {publicKey && (
-                    <IconButton size="small" onClick={() => handleToggleLike(nft.id)} aria-label="like">
-                      {likes[nft.id]?.liked ? (
-                        <FavoriteIcon fontSize="small" sx={{ color: 'rgba(255,255,255,0.9)' }} />
-                      ) : (
-                        <FavoriteBorderIcon fontSize="small" sx={{ color: 'rgba(255,255,255,0.9)' }} />
-                      )}
-                    </IconButton>
-                  )}
+          {loadingNfts ? (
+            <Loading message={t('loading_nfts')} />
+          ) : (
+            <Box className="profile-nft-grid">
+              {nfts.map((nft) => (
+                <Box key={nft.id} className="owned-nft-thumb">
+                  <img src={nft.image} alt={nft.name} />
+                  <Box className="like-row">
+                    <Typography sx={{ fontSize: '0.8rem' }}>
+                      {likes[nft.id]?.count ?? 0}
+                    </Typography>
+                    {publicKey && (
+                      <IconButton size="small" onClick={() => handleToggleLike(nft.id)} aria-label="like">
+                        {likes[nft.id]?.liked ? (
+                          <FavoriteIcon fontSize="small" sx={{ color: 'rgba(255,255,255,0.9)' }} />
+                        ) : (
+                          <FavoriteBorderIcon fontSize="small" sx={{ color: 'rgba(255,255,255,0.9)' }} />
+                        )}
+                      </IconButton>
+                    )}
+                  </Box>
                 </Box>
-              </Box>
-            ))}
-          </Box>
+              ))}
+            </Box>
+          )}
         </Box>
       {isOwner && <BetaRedeem />}
       {isOwner && (

--- a/frontend/src/pages/__tests__/Admin.test.tsx
+++ b/frontend/src/pages/__tests__/Admin.test.tsx
@@ -11,6 +11,9 @@ jest.mock('../../utils/api', () => ({
     if (url.includes('/stats')) {
       return Promise.resolve({ data: { totalWallets: 1, totalPoints: 2, primoHolders: 1, betaCodes: 1, betaCodesRedeemed: 0, primosHeld: 1, walletsWithPrimos: 1, dbMarketCap: 1, floorPrice: 1 } });
     }
+    if (url.includes('/api/user/primos')) {
+      return Promise.resolve({ data: [] });
+    }
     return Promise.resolve({ data: [{ code: 'BETA1', redeemed: false }] });
   }),
   post: jest.fn(() => Promise.resolve({ data: { code: 'B1' } }))

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,4 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;


### PR DESCRIPTION
## Summary
- add a reusable Loading component with spinner
- display Loading spinner across NFT-fetching pages
- setup Jest polyfill for TextEncoder

## Testing
- `npm test src/pages/__tests__/Work.test.tsx` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688d9e4ac260832ab53a8f447fe903da