### PR TITLE
feat: add Primos loading translations

### DIFF
--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -2,6 +2,8 @@
   "connect_wallet": "Connect your wallet to view your Primos NFTs",
   "your_primos_nfts": "Your Primos NFTs",
   "loading_nfts": "Loading your NFTs...",
+  "primos_loading": "Loading Primos...",
+  "loading": "Loading",
   "no_nfts": "No Primos NFTs found in your wallet.",
   "listed": "Listed",
   "not_listed": "Not Listed",
@@ -221,4 +223,5 @@
   ,"work_assigned_to": "Assigned to"
   ,"work_no_groups": "You are not part of any work groups. Join one in your profile."
   ,"telegram_data": "Telegram Data"
+  ,"telegram_error": "Failed to load data"
 }

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -2,6 +2,8 @@
   "connect_wallet": "Conecta tu billetera para ver tus Primos NFTs",
   "your_primos_nfts": "Tus Primos NFTs",
   "loading_nfts": "Cargando tus NFTs...",
+  "primos_loading": "Cargando Primos...",
+  "loading": "Cargando",
   "no_nfts": "No se encontraron Primos NFTs en tu billetera.",
   "listed": "Listado",
   "not_listed": "No Listado",
@@ -220,4 +222,6 @@
   ,"work_pick": "Tomar"
   ,"work_assigned_to": "Asignado a"
   ,"work_no_groups": "No perteneces a ning\u00fan grupo de trabajo. \u00danete en tu perfil."
+  ,"telegram_data": "Datos de Telegram"
+  ,"telegram_error": "Error al cargar datos"
 }

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -166,7 +166,7 @@ const Admin: React.FC = () => {
   }
 
   if (loadingMembers) {
-    return <Loading message={t('loading_nfts')} />;
+    return <Loading message={t('primos_loading')} />;
   }
 
   const filtered = members.filter((m) =>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -249,7 +249,7 @@ const Home: React.FC<{ connected?: boolean }> = ({ connected }) => {
         position: 'relative',
       }}>
         {loadingMembers ? (
-          <Loading message={t('loading_nfts')} />
+          <Loading message={t('primos_loading')} />
         ) : (
           members.length > 0 && (
             <Box>

--- a/frontend/src/pages/PrimoLabs.tsx
+++ b/frontend/src/pages/PrimoLabs.tsx
@@ -120,7 +120,7 @@ const PrimoLabs: React.FC<{ connected?: boolean }> = ({ connected }) => {
         </Card>
       </Box>
       {loadingMembers ? (
-        <Loading message={t('loading_nfts')} />
+        <Loading message={t('primos_loading')} />
       ) : (
         members.length > 0 && (
           <Box>

--- a/frontend/src/pages/Primos.tsx
+++ b/frontend/src/pages/Primos.tsx
@@ -79,7 +79,7 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
       />
       <Box className="primos-list">
         {loadingMembers ? (
-          <Loading message={t('loading_nfts')} />
+          <Loading message={t('primos_loading')} />
         ) : (
           <>
             {filtered.map((m) => (

--- a/frontend/src/pages/Work.tsx
+++ b/frontend/src/pages/Work.tsx
@@ -142,7 +142,7 @@ const Work: React.FC = () => {
         </Box>
       )}
       {loadingRequests ? (
-        <Loading message={t('loading_nfts')} />
+        <Loading message={`${t('loading')}...`} />
       ) : (
         requests.map((r, i) => {
           const reqUser = users[r.requester];


### PR DESCRIPTION
## Summary
- show "Primos loading" when database members are fetched
- add en/es translations for generic loading and telegram errors
- replace work request page loading text

## Testing
- `CI=true npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688da6c0ff84832a9c88109c477d58a3