### PR TITLE
feat: add user badges

### DIFF
--- a/backend/src/main/java/com/primos/model/User.java
+++ b/backend/src/main/java/com/primos/model/User.java
@@ -10,6 +10,7 @@ public class User extends PanacheMongoEntity {
     private SocialLinks socials = new SocialLinks();
     private String pfp;
     private String domain = "";
+    private java.util.List<String> badges = new java.util.ArrayList<>();
     private int points = 0;
     private int pointsToday = 0;
     private String pointsDate = java.time.LocalDate.now().toString();
@@ -62,6 +63,23 @@ public class User extends PanacheMongoEntity {
 
     public void setDomain(String domain) {
         this.domain = domain;
+    }
+
+    public java.util.List<String> getBadges() {
+        return badges;
+    }
+
+    public void setBadges(java.util.List<String> badges) {
+        this.badges = badges;
+    }
+
+    public void addBadge(String badge) {
+        if (badges == null) {
+            badges = new java.util.ArrayList<>();
+        }
+        if (!badges.contains(badge)) {
+            badges.add(badge);
+        }
     }
 
     public int getPoints() {

--- a/backend/src/main/java/com/primos/service/LoginService.java
+++ b/backend/src/main/java/com/primos/service/LoginService.java
@@ -81,6 +81,10 @@ public class LoginService {
                 LOGGER.info(String.format("[LoginService] Non-primo login for publicKey: %s", req.publicKey));
             }
         }
+        if (user.getDomain() != null && user.getDomain().endsWith(".sol")) {
+            user.addBadge("sns");
+            user.persistOrUpdate();
+        }
         return user;
     }
 

--- a/backend/src/main/java/com/primos/service/ProfileService.java
+++ b/backend/src/main/java/com/primos/service/ProfileService.java
@@ -28,6 +28,9 @@ public class ProfileService {
                     throw new jakarta.ws.rs.BadRequestException();
                 }
                 user.setDomain(lower);
+                if (lower.endsWith(".sol")) {
+                    user.addBadge("sns");
+                }
             }
             if (updated.getWorkGroups() != null) {
                 user.setWorkGroups(updated.getWorkGroups());

--- a/backend/src/main/java/com/primos/service/TrenchService.java
+++ b/backend/src/main/java/com/primos/service/TrenchService.java
@@ -2,6 +2,7 @@ package com.primos.service;
 
 import com.primos.model.TrenchContract;
 import com.primos.model.TrenchUser;
+import com.primos.model.User;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.List;
@@ -50,6 +51,11 @@ public class TrenchService {
             tu.setContracts(list);
             tu.setLastSubmittedAt(now);
             tu.persistOrUpdate();
+        }
+        User user = User.find("publicKey", publicKey).firstResult();
+        if (user != null) {
+            user.addBadge("trenches");
+            user.persistOrUpdate();
         }
     }
 

--- a/frontend/src/pages/UserProfile.css
+++ b/frontend/src/pages/UserProfile.css
@@ -103,6 +103,23 @@
   color: rgba(255, 255, 255, 0.9);
 }
 
+.badge-container {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  display: flex;
+  gap: 4px;
+}
+
+.badge-icon {
+  width: 24px;
+  height: 24px;
+  background: #fff;
+  border: 1px solid #000;
+  border-radius: 50%;
+  padding: 2px;
+}
+
 .dialog-overlay {
   background: rgba(0,0,0,0.6);
   position: fixed;

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -16,6 +16,8 @@ import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
+import TerrainIcon from '@mui/icons-material/Terrain';
 import { Link, useParams } from 'react-router-dom';
 import BetaRedeem from '../components/BetaRedeem';
 import { Notification, AppMessage } from '../types';
@@ -41,6 +43,7 @@ type UserDoc = {
   pesos: number;
   artTeam: boolean;
   workGroups: string[];
+  badges?: string[];
 };
 
 const getStatus = (count: number) => {
@@ -302,8 +305,18 @@ const fadeOut = keyframes`
     <>
       <Box className="user-profile">
         {pfpImage && (
-          <Box display="flex" justifyContent="center" mb={2}>
+          <Box display="flex" justifyContent="center" mb={2} position="relative">
             <Avatar src={pfpImage} sx={{ width: 120, height: 120, border: '2px solid #000' }} />
+            {user?.badges && (
+              <Box className="badge-container">
+                {user.badges.includes('sns') && (
+                  <AlternateEmailIcon className="badge-icon" />
+                )}
+                {user.badges.includes('trenches') && (
+                  <TerrainIcon className="badge-icon" />
+                )}
+              </Box>
+            )}
           </Box>
         )}
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>


### PR DESCRIPTION
## Summary
- track user badges in backend and add helpers
- award badges for SNS domains and trenches usage
- display badge icons on profile avatar

## Testing
- `mvn -q test` *(fails: Unresolveable build extension)*
- `npm test -- --watchAll=false` *(fails: TypeError: Cannot read properties of undefined (reading 'then'))*

------
https://chatgpt.com/codex/tasks/task_e_688fdb88043c832a8e0c8d85819f495b