### PR TITLE
feat: show sns badge on profile

### DIFF
--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -307,12 +307,12 @@ const fadeOut = keyframes`
         {pfpImage && (
           <Box display="flex" justifyContent="center" mb={2} position="relative">
             <Avatar src={pfpImage} sx={{ width: 120, height: 120, border: '2px solid #000' }} />
-            {user?.badges && (
+            {(user?.badges?.length || primaryDomain) && (
               <Box className="badge-container">
-                {user.badges.includes('sns') && (
-                  <AlternateEmailIcon className="badge-icon" />
+                {(user?.badges?.includes('sns') || primaryDomain) && (
+                  <AlternateEmailIcon className="badge-icon" aria-label="sns-badge" />
                 )}
-                {user.badges.includes('trenches') && (
+                {user?.badges?.includes('trenches') && (
                   <TerrainIcon className="badge-icon" />
                 )}
               </Box>

--- a/frontend/src/pages/__tests__/UserProfile.test.tsx
+++ b/frontend/src/pages/__tests__/UserProfile.test.tsx
@@ -37,6 +37,11 @@ jest.mock('../../utils/api', () => ({
   }}))
 }));
 
+jest.mock('../../utils/sns', () => ({
+  getPrimaryDomainName: jest.fn(() => Promise.resolve('my.sol')),
+  verifyDomainOwnership: jest.fn(),
+}));
+
 jest.mock('../../services/helius', () => ({
   getAssetsByCollection: jest.fn(() => Promise.resolve([{ id: 't1', image: 'i', name: 'n', listed: false }])),
   getNFTByTokenAddress: jest.fn(() => Promise.resolve(null))
@@ -63,6 +68,17 @@ describe('UserProfile', () => {
 
     const walletText = await screen.findByText(/Wallet/i);
     expect(walletText.textContent).toContain('my.sol');
+  });
+
+  test('shows SNS badge when domain present', async () => {
+    mockUseWallet.mockReturnValue({ publicKey: { toBase58: () => 'pubkey123' } });
+    render(
+      <I18nextProvider i18n={i18n}>
+        <UserProfile />
+      </I18nextProvider>
+    );
+
+    expect(await screen.findByLabelText('sns-badge')).toBeTruthy();
   });
 
   test('renders twitter and website links', async () => {


### PR DESCRIPTION
## Summary
- show SNS badge next to profile picture when user has primary SNS domain
- cover SNS badge rendering with tests

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68900ce80274832aa6edb8140bc560d3