### PR TITLE
feat: show token metadata in trenches

### DIFF
--- a/frontend/src/components/TokenPanel.css
+++ b/frontend/src/components/TokenPanel.css
@@ -1,0 +1,26 @@
+.token-panel {
+  background: rgba(30, 30, 30, 0.9);
+  color: #fff;
+  border: 1px solid #888;
+  border-radius: 8px;
+  padding: 1rem;
+  width: 90vw;
+  max-width: 380px;
+  position: fixed;
+  top: 50%;
+  left: calc(50% + 220px);
+  transform: translate(-50%, -50%);
+}
+
+.token-close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  color: #fff;
+}
+
+@media (min-width: 700px) {
+  .token-panel {
+    max-width: 500px;
+  }
+}

--- a/frontend/src/components/TokenPanel.tsx
+++ b/frontend/src/components/TokenPanel.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+import { useTranslation } from 'react-i18next';
+import { fetchTokenMetadata, TokenMetadata } from '../services/token';
+import './TokenPanel.css';
+
+interface TokenPanelProps {
+  contract: string | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+const TokenPanel: React.FC<TokenPanelProps> = ({ contract, open, onClose }) => {
+  const { t } = useTranslation();
+  const [data, setData] = useState<TokenMetadata | null>(null);
+
+  useEffect(() => {
+    if (!open || !contract) return;
+    fetchTokenMetadata(contract)
+      .then(setData)
+      .catch(() => setData(null));
+  }, [open, contract]);
+
+  useEffect(() => {
+    if (!open) setData(null);
+  }, [open]);
+
+  if (!open || !contract) return null;
+
+  return (
+    <Box className="token-panel" sx={{ zIndex: 1300 }}>
+      <Typography className="dialog-title">{t('token_metadata')}</Typography>
+      <IconButton
+        className="token-close"
+        onClick={onClose}
+        aria-label={t('close')}
+        size="small"
+      >
+        <CloseIcon fontSize="small" />
+      </IconButton>
+      <Box sx={{ maxHeight: 400, overflowY: 'auto', mt: 1 }}>
+        {data ? (
+          <>
+            {data.image && (
+              <Box
+                component="img"
+                src={data.image}
+                alt={data.name}
+                sx={{ width: '100%', borderRadius: 1, mb: 1 }}
+              />
+            )}
+            {Object.entries(data)
+              .filter(([k]) => k !== 'image' && (data as any)[k])
+              .map(([k, v]) => (
+                <Typography key={k} variant="body2" sx={{ mb: 1 }}>
+                  {k}: {v as string}
+                </Typography>
+              ))}
+          </>
+        ) : (
+          <Typography variant="body2">{t('loading')}...</Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default TokenPanel;

--- a/frontend/src/components/__tests__/TokenPanel.test.tsx
+++ b/frontend/src/components/__tests__/TokenPanel.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../i18n';
+import TokenPanel from '../TokenPanel';
+import * as service from '../../services/token';
+
+jest.mock('../../services/token');
+
+describe('TokenPanel', () => {
+  test('renders token metadata', async () => {
+    (service.fetchTokenMetadata as jest.Mock).mockResolvedValueOnce({
+      name: 'cat',
+      symbol: 'CAT',
+      description: 'desc',
+      image: 'img',
+    });
+    render(
+      <I18nextProvider i18n={i18n}>
+        <TokenPanel contract="c1" open={true} onClose={() => {}} />
+      </I18nextProvider>
+    );
+    expect(await screen.findByText('cat')).toBeTruthy();
+    expect(service.fetchTokenMetadata).toHaveBeenCalledWith('c1');
+  });
+
+  test('calls onClose', async () => {
+    (service.fetchTokenMetadata as jest.Mock).mockResolvedValueOnce({});
+    const onClose = jest.fn();
+    render(
+      <I18nextProvider i18n={i18n}>
+        <TokenPanel contract="c1" open={true} onClose={onClose} />
+      </I18nextProvider>
+    );
+    const btn = await screen.findByLabelText(/close/i);
+    fireEvent.click(btn);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -229,4 +229,6 @@
   ,"work_no_groups": "You are not part of any work groups. Join one in your profile."
   ,"telegram_data": "Telegram Data"
   ,"telegram_error": "Failed to load data"
+  ,"token_metadata": "Token Metadata"
+  ,"token_error": "Failed to load metadata"
 }

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -206,27 +206,29 @@
   "experiment2_title": "Calcomanías",
   "experiment2_desc": "Ordena calcomanías de tus Primos NFTs con códigos QR que enlazan al marketplace y a tus redes. El 5% del costo apoya al DAO.",
   "order_sticker": "Pedir calcomanía",
-  "stickers_order_thanks": "¡Pronto podrás completar tu pedido!"
- ,"experiment3_title": "Trincheras"
- ,"experiment3_desc": "Ingresa direcciones de contrato para hacer crecer las trincheras. Las burbujas aumentan al unirse más usuarios."
- ,"enter_contract": "Ingresa dirección de contrato"
- ,"add_contract": "Agregar Contrato"
- ,"my_contracts": "Mis Contratos"
- ,"all_users": "Todos los Usuarios"
- ,"all_contracts": "Todos los Contratos"
- ,"scanner": "Escáner"
- ,"no_scans": "Aún no has escaneado contratos."
- ,"work_title": "Solicitudes de Arte"
- ,"work_join_label": "Seleccionar Grupos de Trabajo"
- ,"work_group_label": "Grupo de Trabajo"
- ,"work_art": "Arte"
- ,"work_dev": "Desarrollo"
- ,"work_other": "Otros"
- ,"work_request_placeholder": "Describe tu solicitud"
- ,"work_submit": "Enviar"
-  ,"work_pick": "Tomar"
-  ,"work_assigned_to": "Asignado a"
-  ,"work_no_groups": "No perteneces a ning\u00fan grupo de trabajo. \u00danete en tu perfil."
-  ,"telegram_data": "Datos de Telegram"
-  ,"telegram_error": "Error al cargar datos"
+  "stickers_order_thanks": "¡Pronto podrás completar tu pedido!",
+  "experiment3_title": "Trincheras",
+  "experiment3_desc": "Ingresa direcciones de contrato para hacer crecer las trincheras. Las burbujas aumentan al unirse más usuarios.",
+  "enter_contract": "Ingresa dirección de contrato",
+  "add_contract": "Agregar Contrato",
+  "my_contracts": "Mis Contratos",
+  "all_users": "Todos los Usuarios",
+  "all_contracts": "Todos los Contratos",
+  "scanner": "Escáner",
+  "no_scans": "Aún no has escaneado contratos.",
+  "work_title": "Solicitudes de Arte",
+  "work_join_label": "Seleccionar Grupos de Trabajo",
+  "work_group_label": "Grupo de Trabajo",
+  "work_art": "Arte",
+  "work_dev": "Desarrollo",
+  "work_other": "Otros",
+  "work_request_placeholder": "Describe tu solicitud",
+  "work_submit": "Enviar",
+  "work_pick": "Tomar",
+  "work_assigned_to": "Asignado a",
+  "work_no_groups": "No perteneces a ningún grupo de trabajo. Únete en tu perfil.",
+  "telegram_data": "Datos de Telegram",
+  "telegram_error": "Error al cargar datos",
+  "token_metadata": "Metadatos del token",
+  "token_error": "Error al cargar metadatos"
 }

--- a/frontend/src/pages/Trenches.css
+++ b/frontend/src/pages/Trenches.css
@@ -13,7 +13,10 @@
 }
 
 .bubble {
-  background: #1976d2;
+  background-color: #1976d2;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   color: #fff;
   border-radius: 50%;
   display: flex;

--- a/frontend/src/pages/Trenches.tsx
+++ b/frontend/src/pages/Trenches.tsx
@@ -11,6 +11,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useTranslation } from 'react-i18next';
 import { fetchTrenchData, submitTrenchContract } from '../services/trench';
 import TelegramPanel from '../components/TelegramPanel';
+import TokenPanel from '../components/TokenPanel';
 import MessageModal from '../components/MessageModal';
 import { AppMessage } from '../types';
 import './Trenches.css';
@@ -187,7 +188,12 @@ const Trenches: React.FC = () => {
                     <Box
                       key={c}
                       className="bubble"
-                      sx={{ width: size, height: size, fontSize: size / 5 }}
+                      sx={{
+                        width: size,
+                        height: size,
+                        fontSize: size / 5,
+                        backgroundImage: meta?.image ? `url(${meta.image})` : undefined,
+                      }}
                       onClick={() => setOpenContract(c)}
                     >
                       {short}
@@ -252,11 +258,17 @@ const Trenches: React.FC = () => {
                   40,
                   Math.min(100, 40 + count * 10)
                 );
+                const meta = data.contracts.find((cc) => cc.contract === c);
                 return (
                   <Box
                     key={c}
                     className="bubble"
-                    sx={{ width: size, height: size, fontSize: size / 5 }}
+                    sx={{
+                      width: size,
+                      height: size,
+                      fontSize: size / 5,
+                      backgroundImage: meta?.image ? `url(${meta.image})` : undefined,
+                    }}
                     onClick={() => setOpenContract(c)}
                   >
                     {short}
@@ -298,11 +310,17 @@ const Trenches: React.FC = () => {
                   40,
                   Math.min(100, 40 + c.count * 10)
                 );
+                const meta = data.contracts.find((cc) => cc.contract === c.contract);
                 return (
                   <Box
                     key={c.contract}
                     className="bubble"
-                    sx={{ width: size, height: size, fontSize: size / 5 }}
+                    sx={{
+                      width: size,
+                      height: size,
+                      fontSize: size / 5,
+                      backgroundImage: meta?.image ? `url(${meta.image})` : undefined,
+                    }}
                     onClick={() => setOpenContract(c.contract)}
                   >
                     {short}
@@ -341,11 +359,17 @@ const Trenches: React.FC = () => {
                     ? `${c.contract.slice(0, 3)}...${c.contract.slice(-4)}`
                     : c.contract;
                 const size = 60;
+                const meta = data.contracts.find((cc) => cc.contract === c.contract);
                 return (
                   <Box
                     key={c.contract}
                     className="bubble"
-                    sx={{ width: size, height: size, fontSize: size / 5 }}
+                    sx={{
+                      width: size,
+                      height: size,
+                      fontSize: size / 5,
+                      backgroundImage: meta?.image ? `url(${meta.image})` : undefined,
+                    }}
                     onClick={() => setOpenContract(c.contract)}
                   >
                     {short}
@@ -369,6 +393,11 @@ const Trenches: React.FC = () => {
         </>
       )}
       <TelegramPanel
+        contract={openContract}
+        open={openContract !== null}
+        onClose={() => setOpenContract(null)}
+      />
+      <TokenPanel
         contract={openContract}
         open={openContract !== null}
         onClose={() => setOpenContract(null)}

--- a/frontend/src/pages/__tests__/Trenches.test.tsx
+++ b/frontend/src/pages/__tests__/Trenches.test.tsx
@@ -6,6 +6,7 @@ import i18n from '../../i18n';
 import Trenches from '../Trenches';
 import * as trenchService from '../../services/trench';
 import * as telegramService from '../../services/telegram';
+import * as tokenService from '../../services/token';
 
 jest.mock('../../services/trench', () => ({
   fetchTrenchData: jest.fn(() =>
@@ -18,6 +19,9 @@ jest.mock('../../services/trench', () => ({
 }));
 jest.mock('../../services/telegram', () => ({
   fetchTelegramData: jest.fn(() => Promise.resolve([])),
+}));
+jest.mock('../../services/token', () => ({
+  fetchTokenMetadata: jest.fn(() => Promise.resolve({})),
 }));
 
 describe('Trenches page', () => {
@@ -92,6 +96,7 @@ describe('Trenches page', () => {
     const bubble = await screen.findByText('c1');
     bubble.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(telegramService.fetchTelegramData).toHaveBeenCalledWith('c1');
+    expect(tokenService.fetchTokenMetadata).toHaveBeenCalledWith('c1');
     expect(await screen.findByText(/Telegram Data/i)).toBeTruthy();
   });
 });

--- a/frontend/src/services/__tests__/token.test.ts
+++ b/frontend/src/services/__tests__/token.test.ts
@@ -1,0 +1,42 @@
+import { fetchTokenMetadata } from '../token';
+import * as helius from '../helius';
+
+jest.mock('../helius');
+
+describe('token service', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('fetchTokenMetadata maps fields', async () => {
+    (helius.getNFTByTokenAddress as jest.Mock).mockResolvedValue({
+      id: 'id',
+      image: 'img',
+      name: 'name',
+      listed: false,
+      metadata: {
+        symbol: 'SYM',
+        description: 'desc',
+        showName: true,
+        createdOn: 'source',
+        twitter: 'tw',
+      },
+    });
+    const meta = await fetchTokenMetadata('c1');
+    expect(meta).toEqual({
+      name: 'name',
+      symbol: 'SYM',
+      description: 'desc',
+      image: 'img',
+      showName: true,
+      createdOn: 'source',
+      twitter: 'tw',
+    });
+  });
+
+  test('fetchTokenMetadata returns null on missing data', async () => {
+    (helius.getNFTByTokenAddress as jest.Mock).mockResolvedValue(null);
+    const meta = await fetchTokenMetadata('c1');
+    expect(meta).toBeNull();
+  });
+});

--- a/frontend/src/services/token.ts
+++ b/frontend/src/services/token.ts
@@ -1,0 +1,33 @@
+import { getNFTByTokenAddress } from './helius';
+
+export interface TokenMetadata {
+  name?: string;
+  symbol?: string;
+  description?: string;
+  image?: string;
+  showName?: boolean;
+  createdOn?: string;
+  twitter?: string;
+}
+
+export const fetchTokenMetadata = async (
+  contract: string
+): Promise<TokenMetadata | null> => {
+  try {
+    const nft = await getNFTByTokenAddress(contract);
+    if (!nft || !nft.metadata) return null;
+    const meta = nft.metadata as any;
+    return {
+      name: meta.name || nft.name,
+      symbol: meta.symbol,
+      description: meta.description,
+      image: nft.image || meta.image,
+      showName: meta.showName,
+      createdOn: meta.createdOn,
+      twitter: meta.twitter,
+    };
+  } catch (error) {
+    console.error('fetchTokenMetadata error', error);
+    return null;
+  }
+};

--- a/frontend/src/services/trench.ts
+++ b/frontend/src/services/trench.ts
@@ -9,6 +9,7 @@ export interface TrenchContract {
   count: number;
   source?: string;
   model?: string;
+  image?: string;
 }
 
 export interface TrenchUser {
@@ -25,6 +26,12 @@ export interface TrenchData {
 
 export const fetchTrenchData = async (): Promise<TrenchData> => {
   const res = await api.get<TrenchData>('/api/trench');
+  const contracts = await Promise.all(
+    res.data.contracts.map(async (c) => {
+      const nft = await getNFTByTokenAddress(c.contract);
+      return { ...c, image: nft?.image } as TrenchContract;
+    })
+  );
   const users = await Promise.all(
     res.data.users.map(async (u) => {
       let image = '';
@@ -41,7 +48,7 @@ export const fetchTrenchData = async (): Promise<TrenchData> => {
       return { ...u, pfp: image } as TrenchUser;
     })
   );
-  return { contracts: res.data.contracts, users };
+  return { contracts, users };
 };
 
 export const submitTrenchContract = async (

--- a/frontend/src/utils/__tests__/helius.test.ts
+++ b/frontend/src/utils/__tests__/helius.test.ts
@@ -52,12 +52,13 @@ describe('helius utilities', () => {
     const mockFetch = jest.fn().mockResolvedValue(response);
     (global as any).fetch = mockFetch;
     const nft = await getNFTByTokenAddress('token');
-    expect(nft).toEqual({
+    expect(nft).toMatchObject({
       id: 'id',
       image: 'img',
       name: 'name',
       listed: true,
       attributes: [],
+      metadata: { name: 'name' },
     });
     const cached = await getNFTByTokenAddress('token');
     expect(cached).toEqual(nft);

--- a/frontend/src/utils/helius.ts
+++ b/frontend/src/utils/helius.ts
@@ -4,6 +4,9 @@ export interface HeliusNFT {
   name: string;
   listed: boolean;
   attributes?: { trait_type: string; value: string }[];
+  symbol?: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
 }
 
 const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
@@ -172,12 +175,16 @@ export const getNFTByTokenAddress = async (
     const data = await response.json();
     const item = data.result;
     if (!item) return null;
+    const metadata = item.content?.metadata || {};
     const nft = {
       id: item.id,
       image: item.content?.links?.image || '/fallback.png',
-      name: item.content?.metadata?.name || item.id,
+      name: metadata?.name || item.id,
       listed: !!item.listing || !!item.marketplace,
-      attributes: item.content?.metadata?.attributes || [],
+      attributes: metadata?.attributes || [],
+      symbol: metadata?.symbol,
+      description: metadata?.description,
+      metadata,
     } as HeliusNFT;
     nftCache[tokenAddress] = nft;
     return nft;


### PR DESCRIPTION
## Summary
- display token metadata in a new TokenPanel for selected contracts
- add token metadata fetching via Helius and show metadata image as bubble background
- update trench data service and tests for new token metadata panel

## Testing
- `npm test -- --watchAll=false` *(fails: TypeError Cannot read properties of undefined and axios module parse errors)*
- `mvn -q test` *(fails: unresolved Maven dependencies, network unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68901a3e23e4832aaebf120b73df292e