### PR TITLE
Import trench types to include image field

### DIFF
--- a/frontend/src/pages/Trenches.tsx
+++ b/frontend/src/pages/Trenches.tsx
@@ -9,31 +9,18 @@ import Avatar from '@mui/material/Avatar';
 import IconButton from '@mui/material/IconButton';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useTranslation } from 'react-i18next';
-import { fetchTrenchData, submitTrenchContract } from '../services/trench';
+import {
+  fetchTrenchData,
+  submitTrenchContract,
+  TrenchContract,
+  TrenchUser,
+  TrenchData,
+} from '../services/trench';
 import TelegramPanel from '../components/TelegramPanel';
 import TokenPanel from '../components/TokenPanel';
 import MessageModal from '../components/MessageModal';
 import { AppMessage } from '../types';
 import './Trenches.css';
-
-interface TrenchContract {
-  contract: string;
-  count: number;
-  source?: string;
-  model?: string;
-}
-
-interface TrenchUser {
-  publicKey: string;
-  pfp: string;
-  count: number;
-  contracts: string[];
-}
-
-interface TrenchData {
-  contracts: TrenchContract[];
-  users: TrenchUser[];
-}
 
 const Trenches: React.FC = () => {
   const { publicKey } = useWallet();


### PR DESCRIPTION
## Summary
- reuse trench data interfaces instead of redefining them in the Trenches page

## Testing
- `npm run build`
- `npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6890230a03ac832aa5a8278c35da592e