### PR TITLE
Adjust contract panel for mobile

### DIFF
--- a/frontend/src/components/ContractPanel.css
+++ b/frontend/src/components/ContractPanel.css
@@ -12,6 +12,7 @@
   padding: 1rem;
   width: 90vw;
   max-width: 800px;
+  box-sizing: border-box;
   position: fixed;
   top: 50%;
   left: 50%;
@@ -54,8 +55,12 @@
 
 @media (max-width: 700px) {
   .contract-content {
-    max-width: 380px;
+    width: 100vw;
+    max-width: 700px;
   }
+}
+
+@media (max-width: 500px) {
   .contract-panels {
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary
- ensure trench token dialog uses full viewport width up to 700px
- stack panel columns only on very small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689038a7e324832a94cd641eb13afcaf