### PR TITLE
Shrink contract token image for mobile layout

### DIFF
--- a/frontend/src/components/ContractPanel.css
+++ b/frontend/src/components/ContractPanel.css
@@ -39,10 +39,22 @@
   padding: 1rem;
 }
 
+.token-info {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
 .token-image {
-  width: 100%;
-  border-radius: 4px;
-  margin-bottom: 1rem;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.token-metadata {
+  flex: 1;
 }
 
 .telegram-list {

--- a/frontend/src/components/ContractPanel.tsx
+++ b/frontend/src/components/ContractPanel.tsx
@@ -124,7 +124,7 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose }
           <Box className="token-panel">
             <Typography className="dialog-title">{t('token_metadata')}</Typography>
             {token ? (
-              <>
+              <Box className="token-info">
                 {token.image && (
                   <Box
                     component="img"
@@ -133,14 +133,16 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose }
                     className="token-image"
                   />
                 )}
-                {Object.entries(token)
-                  .filter(([k]) => k !== 'image' && (token as any)[k])
-                  .map(([k, v]) => (
-                    <Typography key={k} variant="body2" sx={{ mb: 1 }}>
-                      {k}: {v as string}
-                    </Typography>
-                  ))}
-              </>
+                <Box className="token-metadata">
+                  {Object.entries(token)
+                    .filter(([k]) => k !== 'image' && (token as any)[k])
+                    .map(([k, v]) => (
+                      <Typography key={k} variant="body2" sx={{ mb: 1 }}>
+                        {k}: {v as string}
+                      </Typography>
+                    ))}
+                </Box>
+              </Box>
             ) : (
               <Typography variant="body2">{t('loading')}...</Typography>
             )}


### PR DESCRIPTION
## Summary
- show token metadata with a compact profile-style image
- use flex layout so telegram panel and metadata fit on mobile

## Testing
- `CI=true npm test` *(fails: Helius API key not configured, import syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68903d46647c832aa26a92459a1aaa07