### PR TITLE
feat: improve contract panel mobile UI

### DIFF
--- a/frontend/src/components/ContractPanel.css
+++ b/frontend/src/components/ContractPanel.css
@@ -4,6 +4,10 @@
   inset: 0;
 }
 
+:root {
+  --navbar-height: 64px;
+}
+
 .contract-content {
   background: rgba(30, 30, 30, 0.9);
   color: #fff;
@@ -14,16 +18,30 @@
   max-width: 800px;
   box-sizing: border-box;
   position: fixed;
-  top: 50%;
+  top: var(--navbar-height);
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
+  max-height: calc(95vh - var(--navbar-height));
+  overflow-y: auto;
 }
 
 .contract-close {
   position: absolute;
-  top: 4px;
-  right: 4px;
+  top: 8px;
+  right: 8px;
   color: #fff;
+  background: #333;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.contract-close:hover {
+  background: #fff;
+  color: #000;
 }
 
 .contract-panels {

--- a/frontend/src/components/ContractPanel.tsx
+++ b/frontend/src/components/ContractPanel.tsx
@@ -41,10 +41,11 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose }
     setLoading(true);
     setError(null);
     Promise.all([
-      fetchTokenMetadata(contract).catch(() => null),
-      api
-        .get<TelegramData>(`/api/telegram/${contract}`)
-        .then((res) => res.data)
+      Promise.resolve(fetchTokenMetadata(contract)).catch(() => null),
+      Promise.resolve(
+        api.get<TelegramData>(`/api/telegram/${contract}`)
+      )
+        .then((res) => res?.data)
         .catch((err) => {
           console.error(err);
           return null;
@@ -106,14 +107,15 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose }
     <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
       <Dialog.Overlay className="contract-overlay" />
       <Dialog.Content className="contract-content">
-        <IconButton
-          className="contract-close"
-          onClick={onClose}
-          aria-label={t('close')}
-          size="small"
-        >
-          <CloseIcon fontSize="small" />
-        </IconButton>
+        <Dialog.Close asChild>
+          <IconButton
+            className="contract-close"
+            aria-label={t('close')}
+            size="small"
+          >
+            <CloseIcon fontSize="medium" />
+          </IconButton>
+        </Dialog.Close>
         {loading && <Typography variant="body2">{t('loading')}...</Typography>}
         {error && (
           <Typography color="error" variant="body2">

--- a/frontend/src/pages/__tests__/Trenches.test.tsx
+++ b/frontend/src/pages/__tests__/Trenches.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '../../i18n';
@@ -41,8 +41,11 @@ describe('Trenches page', () => {
         </I18nextProvider>
       </MemoryRouter>
     );
-    expect(screen.getByText(/Trenches/i)).toBeTruthy();
-    expect(screen.getByRole('button', { name: /Add Contract/i })).toBeDisabled();
+    expect(screen.getByRole('heading', { name: /Trenches/i })).toBeTruthy();
+    expect(
+      (screen.getByRole('button', { name: /Add Contract/i }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
     expect(screen.getByRole('button', { name: /My Contracts/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /All Contracts/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /Scanner/i })).toBeTruthy();
@@ -106,8 +109,12 @@ describe('Trenches page', () => {
     allBtn.click();
     const bubble = await screen.findByLabelText('c1');
     bubble.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    expect(tokenService.fetchTokenMetadata).toHaveBeenCalledWith('c1');
-    expect(api.get).toHaveBeenCalledWith('/api/telegram/c1');
+    await waitFor(() =>
+      expect(tokenService.fetchTokenMetadata).toHaveBeenCalledWith('c1')
+    );
+    await waitFor(() =>
+      expect(api.get).toHaveBeenCalledWith('/api/telegram/c1')
+    );
     expect(await screen.findByText(/Telegram Data/i)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- make contract details panel sit beneath nav bar with scrollable content
- style top-right close button and wire up Dialog.Close for accessibility
- adjust tests for asynchronous panel loading

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890b57377c4832a9691a8da10f5cb93