### PR TITLE
feat: support cross-chain token info

### DIFF
--- a/frontend/src/components/ContractPanel.tsx
+++ b/frontend/src/components/ContractPanel.tsx
@@ -6,8 +6,12 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import { useTranslation } from 'react-i18next';
-import { fetchTokenMetadata, TokenMetadata } from '../services/token';
-import { getTokenInfo, HeliusTokenInfo } from '../services/helius';
+import {
+  fetchTokenMetadata,
+  fetchTokenInfo,
+  TokenMetadata,
+  TokenInfo,
+} from '../services/token';
 import './ContractPanel.css';
 
 interface ContractPanelProps {
@@ -35,7 +39,7 @@ interface TelegramData {
 const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose }) => {
   const { t } = useTranslation();
   const [token, setToken] = useState<TokenMetadata | null>(null);
-  const [tokenInfo, setTokenInfo] = useState<HeliusTokenInfo | null>(null);
+  const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -51,8 +55,8 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose }
     setError(null);
     Promise.all([
       Promise.resolve(fetchTokenMetadata(contract)).catch(() => null),
-      Promise.resolve(getTokenInfo(contract)).catch((err) => {
-        console.error('getTokenInfo error', err);
+      Promise.resolve(fetchTokenInfo(contract)).catch((err) => {
+        console.error('fetchTokenInfo error', err);
         return null;
       }),
     ])

--- a/frontend/src/pages/__tests__/Trenches.test.tsx
+++ b/frontend/src/pages/__tests__/Trenches.test.tsx
@@ -6,7 +6,6 @@ import i18n from '../../i18n';
 import Trenches from '../Trenches';
 import * as trenchService from '../../services/trench';
 import * as tokenService from '../../services/token';
-import api from '../../utils/api';
 
 jest.mock('@solana/wallet-adapter-react', () => ({
   useWallet: () => ({ publicKey: null }),
@@ -24,12 +23,7 @@ jest.mock('../../services/trench', () => ({
 }));
 jest.mock('../../services/token', () => ({
   fetchTokenMetadata: jest.fn(() => Promise.resolve({})),
-}));
-jest.mock('../../utils/api', () => ({
-  __esModule: true,
-  default: {
-    get: jest.fn(() => Promise.resolve({ data: {} })),
-  },
+  fetchTokenInfo: jest.fn(() => Promise.resolve(null)),
 }));
 
 describe('Trenches page', () => {
@@ -113,8 +107,8 @@ describe('Trenches page', () => {
       expect(tokenService.fetchTokenMetadata).toHaveBeenCalledWith('c1')
     );
     await waitFor(() =>
-      expect(api.get).toHaveBeenCalledWith('/api/telegram/c1')
+      expect(tokenService.fetchTokenInfo).toHaveBeenCalledWith('c1')
     );
-    expect(await screen.findByText(/Telegram Data/i)).toBeTruthy();
+    expect(await screen.findByText(/Token Metadata/i)).toBeTruthy();
   });
 });

--- a/frontend/src/services/token.ts
+++ b/frontend/src/services/token.ts
@@ -1,4 +1,5 @@
-import { getNFTByTokenAddress } from './helius';
+import { getNFTByTokenAddress, getTokenInfo as heliusGetTokenInfo } from './helius';
+import type { HeliusTokenInfo } from './helius';
 
 export interface TokenMetadata {
   name?: string;
@@ -28,6 +29,81 @@ export const fetchTokenMetadata = async (
     };
   } catch (error) {
     console.error('fetchTokenMetadata error', error);
+    return null;
+  }
+};
+
+export type TokenInfo = HeliusTokenInfo;
+
+// Fetches token market data using Helius for Solana tokens and
+// Coingecko for EVM tokens (e.g. Ethereum). Falls back to the Helius
+// `getAsset` endpoint to compute market cap when missing.
+export const fetchTokenInfo = async (
+  contract: string
+): Promise<TokenInfo | null> => {
+  // Ethereum addresses start with 0x and are 42 characters long
+  if (/^0x[0-9a-fA-F]{40}$/.test(contract)) {
+    try {
+      const res = await fetch(
+        `https://api.coingecko.com/api/v3/coins/ethereum/contract/${contract}`
+      );
+      if (!res.ok) return null;
+      const data = await res.json();
+      const ticker = data.tickers?.[0];
+      return {
+        tickerBase: ticker?.base,
+        tickerTarget: ticker?.target,
+        tickerMarketName: ticker?.market?.name,
+        marketCap: data.market_data?.market_cap?.usd,
+        priceUsd: data.market_data?.current_price?.usd,
+        fdvUsd: data.market_data?.fully_diluted_valuation?.usd,
+        volume24hUsd: data.market_data?.total_volume?.usd,
+        change1hPercent:
+          data.market_data?.price_change_percentage_1h_in_currency?.usd,
+      };
+    } catch (e) {
+      console.error('fetchTokenInfo (coingecko) error', e);
+      return null;
+    }
+  }
+
+  try {
+    // First attempt to use Helius getTokenInfo
+    const info = await heliusGetTokenInfo(contract);
+    if (info && info.priceUsd != null && info.marketCap != null) {
+      return info;
+    }
+
+    // Fallback to getAsset to compute price and market cap
+    const apiKey = process.env.REACT_APP_HELIUS_API_KEY;
+    if (!apiKey) return info;
+    const response = await fetch(
+      `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: '1',
+          method: 'getAsset',
+          params: {
+            id: contract,
+            displayOptions: { showFungibleTokens: true },
+          },
+        }),
+      }
+    );
+    if (!response.ok) return info;
+    const data = await response.json();
+    const tokenInfo = data.result?.token_info;
+    if (!tokenInfo?.price_info) return info;
+    const price = tokenInfo.price_info.price_per_token as number;
+    const { supply, decimals } = tokenInfo;
+    const adjustedSupply = supply / Math.pow(10, decimals);
+    const marketCap = price * adjustedSupply;
+    return { ...info, priceUsd: price, marketCap };
+  } catch (e) {
+    console.error('fetchTokenInfo (helius) error', e);
     return null;
   }
 };


### PR DESCRIPTION
## Summary
- add fetchTokenInfo to combine Helius and Coingecko data
- use new token info in ContractPanel for Trenches
- adjust Trenches tests for new token info service

## Testing
- `npm test`
- `npm test -- --watchAll=false` (fails: Jest encountered an unexpected token)
- `mvn -q test` (fails: Unresolveable build extension)


------
https://chatgpt.com/codex/tasks/task_e_6890ec314338832aa581bad93a23955d