### PR TITLE
Fix token bubble tags layout on mobile

### DIFF
--- a/frontend/src/pages/Trenches.css
+++ b/frontend/src/pages/Trenches.css
@@ -28,18 +28,13 @@
   font-size: clamp(0.6rem, 2.5vw, 1rem);
   position: relative;
   cursor: pointer;
-}
-
-.meta-container {
-  position: absolute;
-  bottom: -4px;
-  right: -4px;
-  display: flex;
-  gap: 2px;
-  align-items: center;
+  overflow: visible;
 }
 
 .model-tag {
+  position: absolute;
+  top: -4px;
+  right: -4px;
   background: #fff;
   color: #000;
   border: 1px solid #000;
@@ -47,10 +42,16 @@
   padding: 0 2px;
   font-size: 10px;
   line-height: 1;
+  white-space: nowrap;
 }
 
 .caller-tag {
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
   border: 1px solid #000;
+  width: 16px;
+  height: 16px;
 }
 
 .count-tag {
@@ -93,16 +94,19 @@
     margin-right: 0;
     padding: 1rem;
   }
-  
+
   /* Mobile adjustments for tags */
-  .meta-container {
-    bottom: -2px;
-    right: -2px;
-    gap: 1px;
-  }
   .model-tag {
     font-size: 8px;
+    top: -2px;
+    right: -2px;
     padding: 0 1px;
+  }
+  .caller-tag {
+    width: 14px;
+    height: 14px;
+    bottom: -2px;
+    right: -2px;
   }
   .count-tag {
     font-size: 8px;

--- a/frontend/src/pages/Trenches.tsx
+++ b/frontend/src/pages/Trenches.tsx
@@ -181,21 +181,18 @@ const Trenches: React.FC = () => {
               }}
               onDoubleClick={() => handleCopy(c.contract)}
             >
-              <Box className="meta-container">
-                {c.model && (
-                  <Box className="model-tag">
-                    {c.model === 'model1' ? 'm01' : c.model}
-                  </Box>
-                )}
-                {firstUser && (
-                  <Avatar
-                    src={firstUser.pfp || undefined}
-                    alt={firstUser.publicKey}
-                    className="caller-tag"
-                    sx={{ width: 16, height: 16 }}
-                  />
-                )}
-              </Box>
+              {c.model && (
+                <Box className="model-tag">
+                  {c.model === 'model1' ? 'm01' : c.model}
+                </Box>
+              )}
+              {firstUser && (
+                <Avatar
+                  src={firstUser.pfp || undefined}
+                  alt={firstUser.publicKey}
+                  className="caller-tag"
+                />
+              )}
               <Box className="count-tag">{userCount}</Box>
             </button>
           );


### PR DESCRIPTION
## Summary
- Reposition model tags and caller avatar around token bubbles
- Allow bubbles to show overflow and add responsive sizing

## Testing
- `CI=true npm test` *(fails: Cannot use import statement outside a module, plus multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689124784af8832a8160a7ecca0c6ba6