### PR TITLE
Store CoinGecko market cap during trench scans

### DIFF
--- a/backend/src/main/java/com/primos/resource/TrenchResource.java
+++ b/backend/src/main/java/com/primos/resource/TrenchResource.java
@@ -47,23 +47,14 @@ public class TrenchResource {
         String source = req.getOrDefault("source", "website");
         String model = req.get("model");
 
-        // Extract market cap and domain if provided
-        Double marketCap = null;
+        // Extract domain if provided
         String domain = null;
-
-        if (req.containsKey("marketCap")) {
-            try {
-                marketCap = Double.valueOf(req.get("marketCap"));
-            } catch (NumberFormatException e) {
-                // Ignore invalid market cap values
-            }
-        }
 
         if (req.containsKey("domain")) {
             domain = req.get("domain");
         }
 
-        service.add(publicKey, req.get("contract"), source, model, marketCap, domain);
+        service.add(publicKey, req.get("contract"), source, model, domain);
     }
 
     @GET

--- a/backend/src/main/java/com/primos/service/CoinGeckoService.java
+++ b/backend/src/main/java/com/primos/service/CoinGeckoService.java
@@ -1,0 +1,58 @@
+package com.primos.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class CoinGeckoService {
+    private static final Logger LOG = Logger.getLogger(CoinGeckoService.class.getName());
+    private static final String BASE_URL = "https://api.coingecko.com/api/v3";
+    private static final HttpClient CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    /**
+     * Fetch current USD market cap for a token using CoinGecko's simple token price API.
+     * @param contract Token contract address
+     * @return Market cap in USD, or null if unavailable
+     */
+    public Double fetchMarketCap(String contract) {
+        String url = BASE_URL + "/simple/token_price/solana?contract_addresses=" + contract
+                + "&vs_currencies=usd&include_market_cap=true";
+        try {
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Accept", "application/json")
+                    .timeout(Duration.ofSeconds(30))
+                    .GET()
+                    .build();
+            HttpResponse<String> resp = CLIENT.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200) {
+                LOG.log(java.util.logging.Level.FINE, "CoinGecko HTTP status {0}", resp.statusCode());
+                return null;
+            }
+            try (JsonReader reader = Json.createReader(new StringReader(resp.body()))) {
+                JsonObject obj = reader.readObject();
+                JsonObject token = obj.getJsonObject(contract.toLowerCase());
+                if (token == null) {
+                    token = obj.getJsonObject(contract);
+                }
+                if (token != null && token.containsKey("usd_market_cap")) {
+                    return token.getJsonNumber("usd_market_cap").doubleValue();
+                }
+            }
+        } catch (Exception e) {
+            LOG.log(java.util.logging.Level.FINE, "Error fetching CoinGecko market cap: {0}", e.getMessage());
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/primos/service/TrenchService.java
+++ b/backend/src/main/java/com/primos/service/TrenchService.java
@@ -8,17 +8,21 @@ import com.primos.model.TrenchUser;
 import com.primos.model.User;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 
 @ApplicationScoped
 public class TrenchService {
     private static final long MIN_SUBMIT_INTERVAL_MS = 60_000; // 1 minute cooldown
 
+    @Inject
+    CoinGeckoService coinGeckoService;
+
     public void add(String publicKey, String contract, String source, String model) {
-        add(publicKey, contract, source, model, null, null);
+        add(publicKey, contract, source, model, null);
     }
 
-    public void add(String publicKey, String contract, String source, String model, Double marketCap, String domain) {
+    public void add(String publicKey, String contract, String source, String model, String domain) {
         long now = System.currentTimeMillis();
 
         TrenchContract tc = TrenchContract.find("contract", contract).firstResult();
@@ -30,6 +34,7 @@ public class TrenchService {
             tc.setModel(model);
             tc.setFirstCaller(publicKey);
             tc.setFirstCallerAt(now);
+            Double marketCap = coinGeckoService.fetchMarketCap(contract);
             tc.setFirstCallerMarketCap(marketCap);
             tc.setFirstCallerDomain(domain);
             tc.persist();

--- a/backend/src/test/java/com/primos/service/TrenchServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TrenchServiceTest.java
@@ -10,6 +10,12 @@ public class TrenchServiceTest {
     @Test
     public void testAddIncrementsCounts() {
         TrenchService svc = new TrenchService();
+        svc.coinGeckoService = new CoinGeckoService() {
+            @Override
+            public Double fetchMarketCap(String contract) {
+                return 1000.0;
+            }
+        };
         svc.add("u1", "ca1", "website", null);
         assertThrows(jakarta.ws.rs.BadRequestException.class, () -> svc.add("u1", "ca1", "website", null));
         svc.add("u2", "ca1", "website", null);


### PR DESCRIPTION
## Summary
- Fetch current market cap from CoinGecko when a contract is scanned
- Record fetched market cap and existing domain info for the first caller
- Remove client-supplied market cap from trench submissions

## Testing
- `cd backend && mvn -q test` *(fails: Unresolveable build extension, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891351b82c0832a945790b4c75e8b5e