### PR TITLE
Handle CoinGecko rate limits

### DIFF
--- a/backend/src/main/java/com/primos/resource/CoinGeckoProxyResource.java
+++ b/backend/src/main/java/com/primos/resource/CoinGeckoProxyResource.java
@@ -35,7 +35,8 @@ public class CoinGeckoProxyResource {
             @QueryParam("include_market_cap") String includeMarketCap,
             @QueryParam("include_24hr_vol") String include24hrVol,
             @QueryParam("include_24hr_change") String include24hrChange,
-            @QueryParam("include_last_updated_at") String includeLastUpdatedAt) {
+            @QueryParam("include_last_updated_at") String includeLastUpdatedAt,
+            @QueryParam("x_cg_demo_api_key") String demoApiKey) {
 
         try {
             StringBuilder urlBuilder = new StringBuilder()
@@ -61,6 +62,9 @@ public class CoinGeckoProxyResource {
             }
             if (includeLastUpdatedAt != null) {
                 urlBuilder.append("include_last_updated_at=").append(includeLastUpdatedAt).append("&");
+            }
+            if (demoApiKey != null) {
+                urlBuilder.append("x_cg_demo_api_key=").append(demoApiKey).append("&");
             }
 
             String url = urlBuilder.toString();


### PR DESCRIPTION
## Summary
- queue CoinGecko requests in the frontend to space out calls and retry after rate limit errors
- proxy now forwards optional `x_cg_demo_api_key` to support authenticated CoinGecko access
- use shared CoinGecko service in Trenches page to reduce duplicate external requests

## Testing
- `npm test` *(fails: Jest encountered an unexpected token; SyntaxError: Cannot use import statement outside a module)*
- `mvn -q test` *(fails: Unresolveable build extension: Plugin io.quarkus:quarkus-maven-plugin:3.23.2 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689146cf3888832aaadc40ee1add222e