### PR TITLE
feat: add trader badge for platform links

### DIFF
--- a/backend/src/main/java/com/primos/service/LoginService.java
+++ b/backend/src/main/java/com/primos/service/LoginService.java
@@ -85,6 +85,15 @@ public class LoginService {
             user.addBadge("sns");
             user.persistOrUpdate();
         }
+        if (user.getSocials() != null) {
+            User.SocialLinks links = user.getSocials();
+            if ((links.getSlingshot() != null && !links.getSlingshot().isEmpty())
+                    || (links.getAxiom() != null && !links.getAxiom().isEmpty())
+                    || (links.getVector() != null && !links.getVector().isEmpty())) {
+                user.addBadge("trader");
+                user.persistOrUpdate();
+            }
+        }
         return user;
     }
 

--- a/backend/src/main/java/com/primos/service/ProfileService.java
+++ b/backend/src/main/java/com/primos/service/ProfileService.java
@@ -20,6 +20,12 @@ public class ProfileService {
             user.setBio(updated.getBio());
             if (updated.getSocials() != null) {
                 user.setSocials(updated.getSocials());
+                User.SocialLinks links = updated.getSocials();
+                if ((links.getSlingshot() != null && !links.getSlingshot().isEmpty())
+                        || (links.getAxiom() != null && !links.getAxiom().isEmpty())
+                        || (links.getVector() != null && !links.getVector().isEmpty())) {
+                    user.addBadge("trader");
+                }
             }
             if (updated.getDomain() != null) {
                 String lower = updated.getDomain().toLowerCase();

--- a/backend/src/test/java/com/primos/service/ProfileServiceTest.java
+++ b/backend/src/test/java/com/primos/service/ProfileServiceTest.java
@@ -77,5 +77,6 @@ public class ProfileServiceTest {
         assertEquals("code1", db.getSocials().getSlingshot());
         assertEquals("code2", db.getSocials().getAxiom());
         assertEquals("code3", db.getSocials().getVector());
+        assertTrue(db.getBadges().contains("trader"));
     }
 }

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -18,6 +18,7 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
 import TerrainIcon from '@mui/icons-material/Terrain';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import { GiWhaleTail, GiAnglerFish, GiShrimp } from 'react-icons/gi';
 import { Link, useParams } from 'react-router-dom';
 import BetaRedeem from '../components/BetaRedeem';
@@ -340,6 +341,9 @@ const fadeOut = keyframes`
                 )}
                 {user?.badges?.includes('trenches') && (
                   <TerrainIcon className="badge-icon" />
+                )}
+                {user?.badges?.includes('trader') && (
+                  <TrendingUpIcon className="badge-icon" aria-label="trader-badge" />
                 )}
               </Box>
             )}

--- a/frontend/src/pages/__tests__/UserProfile.test.tsx
+++ b/frontend/src/pages/__tests__/UserProfile.test.tsx
@@ -111,6 +111,40 @@ describe('UserProfile', () => {
     expect(await screen.findByLabelText('sns-badge')).toBeTruthy();
   });
 
+  test('shows trader badge when trading platform present', async () => {
+    mockUseWallet.mockReturnValue({ publicKey: { toBase58: () => 'pubkey123' } });
+    const { default: apiMock } = require('../../utils/api');
+    (apiMock.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        publicKey: 'pubkey123',
+        bio: '',
+        socials: {
+          twitter: '',
+          discord: '',
+          website: '',
+          slingshot: 'code',
+          axiom: '',
+          vector: '',
+        },
+        badges: ['trader'],
+        pfp: '',
+        domain: '',
+        points: 0,
+        pointsToday: 0,
+        pointsDate: 'today',
+        pesos: 0,
+      },
+    });
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <UserProfile />
+      </I18nextProvider>
+    );
+
+    expect(await screen.findByLabelText('trader-badge')).toBeTruthy();
+  });
+
   test('renders twitter and website links', async () => {
     mockUseWallet.mockReturnValue({ publicKey: { toBase58: () => 'pubkey123' } });
     const { default: apiMock } = require('../../utils/api');


### PR DESCRIPTION
## Summary
- award a new `trader` badge when users add Slingshot, Axiom, or Vector handles
- display trader badge with a TrendingUp icon on profile pages
- cover badge assignment in backend and frontend tests

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin io.quarkus:quarkus-maven-plugin:3.23.2 ... Network is unreachable)*
- `CI=true npm test --prefix frontend src/pages/__tests__/UserProfile.test.tsx` *(fails: Cannot read properties of undefined (reading 'then'))*


------
https://chatgpt.com/codex/tasks/task_e_6891494b3f00832aa5c7f33bd7cb3120