### PR TITLE
Add trading platform links to user profiles

### DIFF
--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -84,6 +84,33 @@ const formatWebsiteUrl = (url: string) => {
   return `https://${trimmed}`;
 };
 
+const formatSlingshotUrl = (code: string) => {
+  const trimmed = code.trim();
+  if (!trimmed) return '';
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed;
+  }
+  return `https://slingshot.app/signup?code=${trimmed.replace(/^@/, '')}`;
+};
+
+const formatVectorUrl = (code: string) => {
+  const trimmed = code.trim();
+  if (!trimmed) return '';
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed;
+  }
+  return `https://vec.fun/ref/${trimmed.replace(/^@/, '')}`;
+};
+
+const formatAxiomUrl = (handle: string) => {
+  const trimmed = handle.trim();
+  if (!trimmed) return '';
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed;
+  }
+  return `https://axiom.trade/@${trimmed.replace(/^@/, '')}`;
+};
+
 const UserProfile: React.FC = () => {
   const { publicKey } = useWallet();
   const params = useParams<{ publicKey?: string }>();
@@ -486,36 +513,78 @@ const fadeOut = keyframes`
             </Typography>
           )
         )}
-        <TextField
-          label={t('slingshot')}
-          value={user.socials.slingshot}
-          onChange={(e) =>
-            setUser({ ...user, socials: { ...user.socials, slingshot: e.target.value } })
-          }
-          fullWidth
-          margin="normal"
-          disabled={!isOwner || !isEditing}
-        />
-        <TextField
-          label={t('axiom')}
-          value={user.socials.axiom}
-          onChange={(e) =>
-            setUser({ ...user, socials: { ...user.socials, axiom: e.target.value } })
-          }
-          fullWidth
-          margin="normal"
-          disabled={!isOwner || !isEditing}
-        />
-        <TextField
-          label={t('vector')}
-          value={user.socials.vector}
-          onChange={(e) =>
-            setUser({ ...user, socials: { ...user.socials, vector: e.target.value } })
-          }
-          fullWidth
-          margin="normal"
-          disabled={!isOwner || !isEditing}
-        />
+        {isOwner && isEditing ? (
+          <TextField
+            label={t('slingshot')}
+            value={user.socials.slingshot}
+            onChange={(e) =>
+              setUser({ ...user, socials: { ...user.socials, slingshot: e.target.value } })
+            }
+            fullWidth
+            margin="normal"
+          />
+        ) : (
+          user.socials.slingshot && (
+            <Typography mt={2} sx={{ wordBreak: 'break-word' }}>
+              <strong>{t('slingshot')}</strong>{' '}
+              <a
+                href={formatSlingshotUrl(user.socials.slingshot)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {user.socials.slingshot}
+              </a>
+            </Typography>
+          )
+        )}
+        {isOwner && isEditing ? (
+          <TextField
+            label={t('axiom')}
+            value={user.socials.axiom}
+            onChange={(e) =>
+              setUser({ ...user, socials: { ...user.socials, axiom: e.target.value } })
+            }
+            fullWidth
+            margin="normal"
+          />
+        ) : (
+          user.socials.axiom && (
+            <Typography mt={2} sx={{ wordBreak: 'break-word' }}>
+              <strong>{t('axiom')}</strong>{' '}
+              <a
+                href={formatAxiomUrl(user.socials.axiom)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {user.socials.axiom}
+              </a>
+            </Typography>
+          )
+        )}
+        {isOwner && isEditing ? (
+          <TextField
+            label={t('vector')}
+            value={user.socials.vector}
+            onChange={(e) =>
+              setUser({ ...user, socials: { ...user.socials, vector: e.target.value } })
+            }
+            fullWidth
+            margin="normal"
+          />
+        ) : (
+          user.socials.vector && (
+            <Typography mt={2} sx={{ wordBreak: 'break-word' }}>
+              <strong>{t('vector')}</strong>{' '}
+              <a
+                href={formatVectorUrl(user.socials.vector)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {user.socials.vector}
+              </a>
+            </Typography>
+          )
+        )}
         <TextField
           label={t('sns_domain')}
           value={primaryDomain || ''}

--- a/frontend/src/pages/__tests__/UserProfile.test.tsx
+++ b/frontend/src/pages/__tests__/UserProfile.test.tsx
@@ -150,8 +150,30 @@ describe('UserProfile', () => {
     expect(websiteLink.getAttribute('href')).toBe('https://example.com');
   });
 
-  test('renders trading platform fields', async () => {
+  test('renders trading platform links', async () => {
     mockUseWallet.mockReturnValue({ publicKey: { toBase58: () => 'pubkey123' } });
+    const { default: apiMock } = require('../../utils/api');
+    (apiMock.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        publicKey: 'pubkey123',
+        bio: '',
+        socials: {
+          twitter: '',
+          discord: '',
+          website: '',
+          slingshot: '0x1Juangunner4',
+          axiom: '0x1juan',
+          vector: '0x1JuanGunner4',
+        },
+        pfp: '',
+        domain: 'my.sol',
+        points: 0,
+        pointsToday: 0,
+        pointsDate: 'today',
+        pesos: 0,
+      },
+    });
+
     render(
       <I18nextProvider i18n={i18n}>
         <UserProfile />
@@ -160,9 +182,20 @@ describe('UserProfile', () => {
 
     await screen.findByText(/Wallet/i);
 
-    expect(screen.getByLabelText('Slingshot')).toBeInTheDocument();
-    expect(screen.getByLabelText('Axiom')).toBeInTheDocument();
-    expect(screen.getByLabelText('Vector')).toBeInTheDocument();
+    const slingshotLink = screen.getByRole('link', { name: '0x1Juangunner4' });
+    expect(slingshotLink.getAttribute('href')).toBe(
+      'https://slingshot.app/signup?code=0x1Juangunner4'
+    );
+
+    const axiomLink = screen.getByRole('link', { name: '0x1juan' });
+    expect(axiomLink.getAttribute('href')).toBe(
+      'https://axiom.trade/@0x1juan'
+    );
+
+    const vectorLink = screen.getByRole('link', { name: '0x1JuanGunner4' });
+    expect(vectorLink.getAttribute('href')).toBe(
+      'https://vec.fun/ref/0x1JuanGunner4'
+    );
   });
 
   test('shows cancel button and NFT selector when entering edit mode', async () => {


### PR DESCRIPTION
## Summary
- add Slingshot, Vector, and Axiom link formatting
- show trading platform links on user profiles
- test trading platform link rendering

## Testing
- `CI=true npm test src/pages/__tests__/UserProfile.test.tsx` *(fails: Cannot read properties of undefined (reading 'then'))*

------
https://chatgpt.com/codex/tasks/task_e_68914af19458832aa650cf3a587546fb