### PR TITLE
feat: add icons and validation to profile social links

### DIFF
--- a/frontend/src/pages/__tests__/UserProfile.test.tsx
+++ b/frontend/src/pages/__tests__/UserProfile.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import UserProfile from '../UserProfile';
 import i18n from '../../i18n';
 
 const mockUseWallet = jest.fn();
@@ -72,10 +71,15 @@ jest.mock('../../utils/sns', () => ({
   verifyDomainOwnership: jest.fn(),
 }));
 
-jest.mock('../../services/helius', () => ({
+jest.mock('../../utils/helius', () => ({
+  __esModule: true,
   getAssetsByCollection: jest.fn(() => Promise.resolve([{ id: 't1', image: 'i', name: 'n', listed: false }])),
   getNFTByTokenAddress: jest.fn(() => Promise.resolve(null))
 }));
+
+jest.mock('../../components/BetaRedeem', () => () => null);
+
+const UserProfile = require('../UserProfile').default;
 
 describe('UserProfile', () => {
   test('returns null when wallet not connected', () => {


### PR DESCRIPTION
## Summary
- add icons and regex validation for Twitter, website, Slingshot, Axiom, Vector, and Discord links on profile
- update profile tests with necessary mocks for new imports

## Testing
- `npm test` *(fails: Unable to find elements / Promise undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68915a52f484832a935d37a6437c161d