### PR TITLE
Prevent duplicate trench token submissions

### DIFF
--- a/backend/src/test/java/com/primos/service/TrenchServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TrenchServiceTest.java
@@ -17,13 +17,16 @@ public class TrenchServiceTest {
             }
         };
         svc.add("u1", "ca1", "website", null);
+        TrenchUser u1 = TrenchUser.find("publicKey", "u1").firstResult();
+        u1.setLastSubmittedAt(0L); // bypass cooldown
+        u1.persistOrUpdate();
         assertThrows(jakarta.ws.rs.BadRequestException.class, () -> svc.add("u1", "ca1", "website", null));
         svc.add("u2", "ca1", "website", null);
 
         TrenchContract tc = TrenchContract.find("contract", "ca1").firstResult();
         assertEquals(2, tc.getCount());
 
-        TrenchUser u1 = TrenchUser.find("publicKey", "u1").firstResult();
+        u1 = TrenchUser.find("publicKey", "u1").firstResult();
         assertEquals(1, u1.getCount());
         assertTrue(u1.getContracts().contains("ca1"));
         TrenchUser u2 = TrenchUser.find("publicKey", "u2").firstResult();

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -214,6 +214,8 @@
  ,"experiment3_desc": "Enter contract addresses to grow the trenches. Bubbles expand as more users join."
  ,"enter_contract": "Enter contract address"
  ,"add_contract": "Add Contract"
+ ,"contract_not_onchain": "Contract not found on chain"
+ ,"contract_already_added": "You have already added this contract"
  ,"my_contracts": "My Contracts"
  ,"all_users": "All Users"
  ,"all_contracts": "All Contracts"

--- a/frontend/src/pages/Trenches.tsx
+++ b/frontend/src/pages/Trenches.tsx
@@ -88,9 +88,13 @@ const Trenches: React.FC = () => {
       return;
     }
     
-    await submitTrenchContract(publicKey.toBase58(), input, 'model1', marketCap);
-    setInput('');
-    load();
+    try {
+      await submitTrenchContract(publicKey.toBase58(), input, 'model1', marketCap);
+      setInput('');
+      load();
+    } catch (e: any) {
+      setMessage({ text: t('contract_already_added'), type: 'error' });
+    }
   };
 
   const handleCopy = (contract: string) => {


### PR DESCRIPTION
## Summary
- ensure users cannot submit the same token address to trenches more than once
- surface errors for duplicate submissions in the trenches UI
- add translations for new error messages

## Testing
- `mvn -q test` *(fails: Network is unreachable - could not resolve Maven dependencies)*
- `CI=true npm test --silent` *(fails: SyntaxError Cannot use import statement outside a module; 27 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68915c03f644832ab54da9a1fa29a801