### PR TITLE
Retry CoinGecko market cap fetch

### DIFF
--- a/backend/src/test/java/com/primos/service/TrenchServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TrenchServiceTest.java
@@ -32,4 +32,24 @@ public class TrenchServiceTest {
         TrenchUser u2 = TrenchUser.find("publicKey", "u2").firstResult();
         assertEquals(1, u2.getCount());
     }
+
+    @Test
+    public void testRetriesMarketCapUntilSuccess() {
+        TrenchService svc = new TrenchService();
+        svc.coinGeckoService = new CoinGeckoService() {
+            int attempts = 0;
+
+            @Override
+            protected Double fetchMarketCapOnce(String contract) {
+                attempts++;
+                if (attempts < 3) {
+                    return null;
+                }
+                return 5000.0;
+            }
+        };
+        svc.add("u3", "ca2", "website", null);
+        TrenchContract tc = TrenchContract.find("contract", "ca2").firstResult();
+        assertEquals(5000.0, tc.getFirstCallerMarketCap());
+    }
 }


### PR DESCRIPTION
## Summary
- Retry CoinGecko market cap lookup with multiple attempts
- Test repeated market cap calls until success

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin io.quarkus:quarkus-maven-plugin:3.23.2 or one of its dependencies could not be resolved: Failed to read artifact descriptor for io.quarkus:quarkus-maven-plugin:jar:3.23.2)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689161e598d4832aa5e1cb285e9c7125