### PR TITLE
fix: persist first caller market cap

### DIFF
--- a/backend/src/main/java/com/primos/service/TrenchService.java
+++ b/backend/src/main/java/com/primos/service/TrenchService.java
@@ -82,7 +82,17 @@ public class TrenchService {
     }
 
     public List<TrenchContract> getContracts() {
-        return TrenchContract.listAll();
+        List<TrenchContract> contracts = TrenchContract.listAll();
+        for (TrenchContract tc : contracts) {
+            if (tc.getFirstCallerMarketCap() == null) {
+                Double marketCap = coinGeckoService.fetchMarketCap(tc.getContract());
+                if (marketCap != null) {
+                    tc.setFirstCallerMarketCap(marketCap);
+                    tc.persistOrUpdate();
+                }
+            }
+        }
+        return contracts;
     }
 
     public List<TrenchUser> getUsers() {

--- a/backend/src/test/java/com/primos/resource/TrenchResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/TrenchResourceTest.java
@@ -3,11 +3,21 @@ package com.primos.resource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import com.primos.service.TrenchService;
+import com.primos.service.CoinGeckoService;
 
 class TrenchResourceTest {
     @Test
     void testAddAndGet() {
         TrenchResource res = new TrenchResource();
+        TrenchService service = new TrenchService();
+        service.coinGeckoService = new CoinGeckoService() {
+            @Override
+            public Double fetchMarketCap(String contract) {
+                return 77.0;
+            }
+        };
+        res.service = service;
         res.add("w1", java.util.Map.of("contract", "ca1", "source", "website"));
         TrenchResource.TrenchData data = res.get();
         assertEquals(1, data.contracts.size());

--- a/backend/src/test/java/com/primos/service/TrenchServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TrenchServiceTest.java
@@ -52,4 +52,25 @@ public class TrenchServiceTest {
         TrenchContract tc = TrenchContract.find("contract", "ca2").firstResult();
         assertEquals(5000.0, tc.getFirstCallerMarketCap());
     }
+
+    @Test
+    public void testGetContractsPopulatesMissingMarketCap() {
+        TrenchService svc = new TrenchService();
+        svc.coinGeckoService = new CoinGeckoService() {
+            @Override
+            public Double fetchMarketCap(String contract) {
+                return 42.0;
+            }
+        };
+        TrenchContract tc = new TrenchContract();
+        tc.setContract("ca3");
+        tc.setCount(1);
+        tc.persist();
+        java.util.List<TrenchContract> list = svc.getContracts();
+        TrenchContract updated = list.stream().filter(c -> "ca3".equals(c.getContract())).findFirst().orElse(null);
+        assertNotNull(updated);
+        assertEquals(42.0, updated.getFirstCallerMarketCap());
+        TrenchContract fromDb = TrenchContract.find("contract", "ca3").firstResult();
+        assertEquals(42.0, fromDb.getFirstCallerMarketCap());
+    }
 }


### PR DESCRIPTION
## Summary
- ensure trench service backfills missing first caller market caps from CoinGecko and persists the result
- cover new behavior with tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus:quarkus-bom: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689178f211dc832aa71a6bd7d6083666