### PR TITLE
Allow TrenchService to accept CoinGeckoService in tests

### DIFF
--- a/backend/src/main/java/com/primos/service/TrenchService.java
+++ b/backend/src/main/java/com/primos/service/TrenchService.java
@@ -18,6 +18,10 @@ public class TrenchService {
     @Inject
     CoinGeckoService coinGeckoService;
 
+    public void setCoinGeckoService(CoinGeckoService coinGeckoService) {
+        this.coinGeckoService = coinGeckoService;
+    }
+
     public void add(String publicKey, String contract, String source, String model) {
         add(publicKey, contract, source, model, null);
     }

--- a/backend/src/test/java/com/primos/resource/TrenchResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/TrenchResourceTest.java
@@ -11,12 +11,12 @@ class TrenchResourceTest {
     void testAddAndGet() {
         TrenchResource res = new TrenchResource();
         TrenchService service = new TrenchService();
-        service.coinGeckoService = new CoinGeckoService() {
+        service.setCoinGeckoService(new CoinGeckoService() {
             @Override
             public Double fetchMarketCap(String contract) {
                 return 77.0;
             }
-        };
+        });
         res.service = service;
         res.add("w1", java.util.Map.of("contract", "ca1", "source", "website"));
         TrenchResource.TrenchData data = res.get();


### PR DESCRIPTION
## Summary
- add setter in `TrenchService` to configure `CoinGeckoService`
- update `TrenchResourceTest` to use setter

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68917f38073c832aa6d07d47457bc2c5