### PR TITLE
Update pointsDate on user activity

### DIFF
--- a/backend/src/main/java/com/primos/filter/PointsDateFilter.java
+++ b/backend/src/main/java/com/primos/filter/PointsDateFilter.java
@@ -1,0 +1,28 @@
+package com.primos.filter;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import com.primos.model.User;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Priority(Priorities.USER)
+public class PointsDateFilter implements ContainerRequestFilter {
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String walletKey = requestContext.getHeaderString("X-Public-Key");
+        if (walletKey != null && !walletKey.isEmpty()) {
+            User user = User.find("publicKey", walletKey).firstResult();
+            if (user != null) {
+                user.setPointsDate(LocalDate.now().toString());
+                user.persistOrUpdate();
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/primos/service/LoginService.java
+++ b/backend/src/main/java/com/primos/service/LoginService.java
@@ -1,5 +1,6 @@
 package com.primos.service;
 
+import java.time.LocalDate;
 import java.util.logging.Logger;
 
 import com.primos.model.BetaCode;
@@ -94,6 +95,8 @@ public class LoginService {
                 user.persistOrUpdate();
             }
         }
+        user.setPointsDate(LocalDate.now().toString());
+        user.persistOrUpdate();
         return user;
     }
 


### PR DESCRIPTION
## Summary
- add a request filter that bumps the user's `pointsDate` whenever the frontend hits the API
- ensure login also refreshes `pointsDate`

## Testing
- `mvn -q test` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_e_689189e960c4832a9c57488cbd9e555f