### PR TITLE
Batch trench NFT lookups and refine loading

### DIFF
--- a/frontend/src/pages/Trenches.tsx
+++ b/frontend/src/pages/Trenches.tsx
@@ -43,13 +43,13 @@ const Trenches: React.FC = () => {
     return map;
   }, [data]);
 
-  const load = async () => {
-    setLoading(true);
+  const load = async (showSpinner = true) => {
+    if (showSpinner) setLoading(true);
     try {
       const res = await fetchTrenchData();
       setData(res);
     } finally {
-      setLoading(false);
+      if (showSpinner) setLoading(false);
     }
   };
 
@@ -102,7 +102,7 @@ const Trenches: React.FC = () => {
     try {
       await submitTrenchContract(publicKey.toBase58(), contract, 'model1', marketCap);
       setInput('');
-      await load();
+      await load(false);
     } catch (e: any) {
       setMessage({ text: t('contract_already_added'), type: 'error' });
     } finally {

--- a/frontend/src/services/__tests__/trench.test.ts
+++ b/frontend/src/services/__tests__/trench.test.ts
@@ -6,18 +6,22 @@ jest.mock('../../utils/api');
 jest.mock('../helius');
 
 describe('trench service', () => {
-  test('fetchTrenchData enriches user images', async () => {
+  test('fetchTrenchData enriches images', async () => {
     (api.get as jest.Mock).mockResolvedValue({
       data: {
         contracts: [{ contract: 'c1', count: 1 }],
         users: [{ publicKey: 'u1', pfp: '', count: 1, contracts: [] }],
       },
     });
+    (helius.getNFTsByTokenAddresses as jest.Mock).mockResolvedValue({
+      c1: { image: 'cimg' },
+    });
     (helius.fetchCollectionNFTsForOwner as jest.Mock).mockResolvedValue([
-      { image: 'img' },
+      { image: 'uimg' },
     ]);
     const data = await fetchTrenchData();
-    expect(data.users[0].pfp).toBe('img');
+    expect(data.contracts[0].image).toBe('cimg');
+    expect(data.users[0].pfp).toBe('uimg');
     expect(api.get).toHaveBeenCalledWith('/api/trench');
   });
 

--- a/frontend/src/services/helius.ts
+++ b/frontend/src/services/helius.ts
@@ -9,6 +9,7 @@ export type { HeliusNFT, HeliusTokenInfo } from '../utils/helius';
 export {
   getAssetsByCollection,
   getNFTByTokenAddress,
+  getNFTsByTokenAddresses,
   checkPrimoHolder,
   fetchCollectionNFTsForOwner,
   getTokenInfo,

--- a/frontend/src/services/trench.ts
+++ b/frontend/src/services/trench.ts
@@ -1,6 +1,10 @@
 export type { HeliusNFT } from './helius';
 import api from '../utils/api';
-import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from './helius';
+import {
+  getNFTByTokenAddress,
+  getNFTsByTokenAddresses,
+  fetchCollectionNFTsForOwner,
+} from './helius';
 
 const PRIMO_COLLECTION = process.env.REACT_APP_PRIMOS_COLLECTION!;
 
@@ -38,12 +42,13 @@ export interface TrenchData {
 
 export const fetchTrenchData = async (): Promise<TrenchData> => {
   const res = await api.get<TrenchData>('/api/trench');
-  const contracts = await Promise.all(
-    res.data.contracts.map(async (c) => {
-      const nft = await getNFTByTokenAddress(c.contract);
-      return { ...c, image: nft?.image } as TrenchContract;
-    })
+  const nftMap = await getNFTsByTokenAddresses(
+    res.data.contracts.map((c) => c.contract)
   );
+  const contracts = res.data.contracts.map((c) => ({
+    ...c,
+    image: nftMap[c.contract]?.image,
+  }));
   const users = await Promise.all(
     res.data.users.map(async (u) => {
       let image = '';


### PR DESCRIPTION
## Summary
- fetch trench NFT metadata in batches to reduce loading time
- avoid clearing existing bubbles when adding a new contract
- adjust trench service tests for new batch loader

## Testing
- `CI=true npm test src/services/__tests__/trench.test.ts --runTestsByPath --silent` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68919331f3b0832ab4cd696a29eeaae1