### PR TITLE
Optimize trench data fetching

### DIFF
--- a/frontend/src/services/__tests__/trench.test.ts
+++ b/frontend/src/services/__tests__/trench.test.ts
@@ -2,26 +2,42 @@ import { fetchTrenchData, submitTrenchContract } from '../trench';
 import api from '../../utils/api';
 import * as helius from '../helius';
 
-jest.mock('../../utils/api');
-jest.mock('../helius');
+jest.mock('../../utils/api', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+jest.mock('../helius', () => ({
+  __esModule: true,
+  getNFTsByTokenAddresses: jest.fn(),
+  fetchCollectionNFTsForOwner: jest.fn(),
+}));
 
 describe('trench service', () => {
   test('fetchTrenchData enriches images', async () => {
     (api.get as jest.Mock).mockResolvedValue({
       data: {
         contracts: [{ contract: 'c1', count: 1 }],
-        users: [{ publicKey: 'u1', pfp: '', count: 1, contracts: [] }],
+        users: [
+          { publicKey: 'u1', pfp: 'p1', count: 1, contracts: [] },
+          { publicKey: 'u2', pfp: '', count: 1, contracts: [] },
+        ],
       },
     });
     (helius.getNFTsByTokenAddresses as jest.Mock).mockResolvedValue({
       c1: { image: 'cimg' },
+      p1: { image: 'pimg' },
     });
     (helius.fetchCollectionNFTsForOwner as jest.Mock).mockResolvedValue([
-      { image: 'uimg' },
+      { image: 'u2img' },
     ]);
     const data = await fetchTrenchData();
     expect(data.contracts[0].image).toBe('cimg');
-    expect(data.users[0].pfp).toBe('uimg');
+    expect(data.users[0].pfp).toBe('pimg');
+    expect(data.users[1].pfp).toBe('u2img');
+    expect(helius.getNFTsByTokenAddresses).toHaveBeenCalledWith(['c1', 'p1']);
     expect(api.get).toHaveBeenCalledWith('/api/trench');
   });
 


### PR DESCRIPTION
## Summary
- batch contract and user PFP NFT lookups in a single API call for faster bubble population
- update trench service tests to cover batched fetches

## Testing
- `npm test -- src/services/__tests__/trench.test.ts --watchAll=false`
- `npm test -- --watchAll=false` *(fails: Test Suites: 26 failed, 12 passed, 38 total)*

------
https://chatgpt.com/codex/tasks/task_e_689198b4544c832a86c7a9928dce403c