### PR TITLE
Stream contract bubbles incrementally

### DIFF
--- a/frontend/src/pages/__tests__/Trenches.test.tsx
+++ b/frontend/src/pages/__tests__/Trenches.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '../../i18n';
 import Trenches from '../Trenches';
-import * as trenchService from '../../services/trench';
+import api from '../../utils/api';
 import * as tokenService from '../../services/token';
 
 jest.mock('@solana/wallet-adapter-react', () => ({
@@ -17,21 +17,18 @@ jest.mock('../../contexts/PrimoHolderContext', () => ({
 }));
 
 jest.mock('../../services/trench', () => ({
-  fetchTrenchData: jest.fn(() =>
-    Promise.resolve({
-      contracts: [{ contract: 'c1', count: 1, firstCaller: 'u1' }],
-      users: [
-        {
-          publicKey: 'u1',
-          pfp: '',
-          count: 1,
-          contracts: ['c1'],
-          lastSubmittedAt: 1,
-        },
-      ],
-    })
-  ),
   submitTrenchContract: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../utils/api', () => ({
+  __esModule: true,
+  default: { get: jest.fn(() => Promise.resolve({ data: {} })), post: jest.fn() },
+}));
+
+jest.mock('../../services/helius', () => ({
+  __esModule: true,
+  getNFTByTokenAddress: jest.fn(() => Promise.resolve(null)),
+  fetchCollectionNFTsForOwner: jest.fn(() => Promise.resolve([])),
 }));
 
 jest.mock('../../services/token', () => ({
@@ -40,7 +37,14 @@ jest.mock('../../services/token', () => ({
 }));
 
 describe('Trenches page', () => {
-  test('renders without add button for guests', () => {
+  test('renders without add button for guests', async () => {
+    (api.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        contracts: [],
+        users: [],
+      },
+    });
+
     render(
       <MemoryRouter>
         <I18nextProvider i18n={i18n}>
@@ -53,17 +57,19 @@ describe('Trenches page', () => {
   });
 
   test('displays contract bubble and opens panel', async () => {
-    (trenchService.fetchTrenchData as jest.Mock).mockResolvedValueOnce({
-      contracts: [{ contract: 'c1', count: 1, firstCaller: 'u1' }],
-      users: [
-        {
-          publicKey: 'u1',
-          pfp: '',
-          count: 1,
-          contracts: ['c1'],
-          lastSubmittedAt: 1,
-        },
-      ],
+    (api.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        contracts: [{ contract: 'c1', count: 1, firstCaller: 'u1' }],
+        users: [
+          {
+            publicKey: 'u1',
+            pfp: '',
+            count: 1,
+            contracts: ['c1'],
+            lastSubmittedAt: 1,
+          },
+        ],
+      },
     });
 
     render(


### PR DESCRIPTION
## Summary
- Load trench data via API and append contract bubbles one by one so they render immediately
- Fetch contract and user images individually while UI updates
- Adjust Trenches tests to mock new incremental loading approach

## Testing
- `mvn -q test` *(fails: Unresolveable build extension)*
- `npm test -- --watchAll=false` *(fails: Test Suites: 25 failed, 13 passed)*
- `npm test src/pages/__tests__/Trenches.test.tsx -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6891a2d39f68832aa6b4c7b84044204c