### PR TITLE
Optimize trench contract retrieval

### DIFF
--- a/backend/src/main/java/com/primos/service/TrenchService.java
+++ b/backend/src/main/java/com/primos/service/TrenchService.java
@@ -86,17 +86,7 @@ public class TrenchService {
     }
 
     public List<TrenchContract> getContracts() {
-        List<TrenchContract> contracts = TrenchContract.listAll();
-        for (TrenchContract tc : contracts) {
-            if (tc.getFirstCallerMarketCap() == null) {
-                Double marketCap = coinGeckoService.fetchMarketCap(tc.getContract());
-                if (marketCap != null) {
-                    tc.setFirstCallerMarketCap(marketCap);
-                    tc.persistOrUpdate();
-                }
-            }
-        }
-        return contracts;
+        return TrenchContract.listAll();
     }
 
     public List<TrenchUser> getUsers() {

--- a/backend/src/test/java/com/primos/service/TrenchServiceTest.java
+++ b/backend/src/test/java/com/primos/service/TrenchServiceTest.java
@@ -54,12 +54,13 @@ public class TrenchServiceTest {
     }
 
     @Test
-    public void testGetContractsPopulatesMissingMarketCap() {
+    public void testGetContractsDoesNotFetchMarketCap() {
         TrenchService svc = new TrenchService();
         svc.coinGeckoService = new CoinGeckoService() {
             @Override
             public Double fetchMarketCap(String contract) {
-                return 42.0;
+                fail("fetchMarketCap should not be called");
+                return null; // unreachable
             }
         };
         TrenchContract tc = new TrenchContract();
@@ -67,10 +68,8 @@ public class TrenchServiceTest {
         tc.setCount(1);
         tc.persist();
         java.util.List<TrenchContract> list = svc.getContracts();
-        TrenchContract updated = list.stream().filter(c -> "ca3".equals(c.getContract())).findFirst().orElse(null);
-        assertNotNull(updated);
-        assertEquals(42.0, updated.getFirstCallerMarketCap());
-        TrenchContract fromDb = TrenchContract.find("contract", "ca3").firstResult();
-        assertEquals(42.0, fromDb.getFirstCallerMarketCap());
+        TrenchContract result = list.stream().filter(c -> "ca3".equals(c.getContract())).findFirst().orElse(null);
+        assertNotNull(result);
+        assertNull(result.getFirstCallerMarketCap());
     }
 }


### PR DESCRIPTION
## Summary
- Avoid CoinGecko lookups on trench contract fetches for faster responses
- Ensure trench contract retrieval does not trigger CoinGecko queries

## Testing
- `mvn -q test` *(fails: Could not resolve io.quarkus dependencies, Network is unreachable)*
- `npm test --prefix frontend -- --watchAll=false` *(fails: multiple failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_6891a6eac6a8832a9afd4bf4501e052e