### PR TITLE
feat: expand daily point tracking

### DIFF
--- a/backend/src/main/java/com/primos/model/User.java
+++ b/backend/src/main/java/com/primos/model/User.java
@@ -13,6 +13,8 @@ public class User extends PanacheMongoEntity {
     private java.util.List<String> badges = new java.util.ArrayList<>();
     private int points = 0;
     private int pointsToday = 0;
+    private int iconPointsToday = 0;
+    private int holderPointsToday = 0;
     private String pointsDate = java.time.LocalDate.now().toString();
     private int nftCount = 0;
     private int pesos = 1;
@@ -96,6 +98,22 @@ public class User extends PanacheMongoEntity {
 
     public void setPointsToday(int pointsToday) {
         this.pointsToday = pointsToday;
+    }
+
+    public int getIconPointsToday() {
+        return iconPointsToday;
+    }
+
+    public void setIconPointsToday(int iconPointsToday) {
+        this.iconPointsToday = iconPointsToday;
+    }
+
+    public int getHolderPointsToday() {
+        return holderPointsToday;
+    }
+
+    public void setHolderPointsToday(int holderPointsToday) {
+        this.holderPointsToday = holderPointsToday;
     }
 
     public String getPointsDate() {

--- a/backend/src/main/java/com/primos/service/HolderPointsJob.java
+++ b/backend/src/main/java/com/primos/service/HolderPointsJob.java
@@ -30,7 +30,11 @@ public class HolderPointsJob {
             user.setDaoMember(count > 0);
             int multiplier = 1 + count / 5;
             int add = 18 * multiplier;
-            user.setPoints(user.getPoints() + add);
+            int remaining = PointService.MAX_POINTS_PER_DAY - user.getPointsToday();
+            int toAdd = Math.min(add, Math.max(remaining, 0));
+            user.setPoints(user.getPoints() + toAdd);
+            user.setPointsToday(user.getPointsToday() + toAdd);
+            user.setHolderPointsToday(user.getHolderPointsToday() + toAdd);
             user.persistOrUpdate();
         }
         LOG.info("Awarded holder points to all users");

--- a/backend/src/main/java/com/primos/service/LoginService.java
+++ b/backend/src/main/java/com/primos/service/LoginService.java
@@ -99,6 +99,8 @@ public class LoginService {
         if (!today.equals(user.getPointsDate())) {
             user.setPointsDate(today);
             user.setPointsToday(0);
+            user.setIconPointsToday(0);
+            user.setHolderPointsToday(0);
         }
         user.persistOrUpdate();
         return user;

--- a/backend/src/main/java/com/primos/service/PointService.java
+++ b/backend/src/main/java/com/primos/service/PointService.java
@@ -13,7 +13,8 @@ import jakarta.ws.rs.NotFoundException;
 @ApplicationScoped
 public class PointService {
     private static final Logger LOGGER = Logger.getLogger(PointService.class.getName());
-    private static final int MAX_POINTS_PER_DAY = 1000;
+    public static final int MAX_POINTS_PER_DAY = 1000;
+    public static final int MAX_ICON_POINTS_PER_DAY = 4;
 
     public User addPoint(String publicKey, String walletKey) {
         if (LOGGER.isLoggable(java.util.logging.Level.INFO)) {
@@ -39,7 +40,9 @@ public class PointService {
         if (!today.equals(user.getPointsDate())) {
             user.setPointsDate(today);
             user.setPointsToday(0);
-            LOGGER.info("[PointService] Reset pointsToday for new day");
+            user.setIconPointsToday(0);
+            user.setHolderPointsToday(0);
+            LOGGER.info("[PointService] Reset daily points for new day");
         }
         if (user.getPointsToday() >= MAX_POINTS_PER_DAY) {
             if (LOGGER.isLoggable(java.util.logging.Level.WARNING)) {
@@ -47,12 +50,21 @@ public class PointService {
             }
             throw new BadRequestException("Daily limit reached");
         }
+        if (user.getIconPointsToday() >= MAX_ICON_POINTS_PER_DAY) {
+            if (LOGGER.isLoggable(java.util.logging.Level.WARNING)) {
+                LOGGER.warning(
+                        String.format("[PointService] Daily icon limit reached for user: %s", publicKey));
+            }
+            throw new BadRequestException("Daily icon limit reached");
+        }
         user.setPoints(user.getPoints() + 1);
         user.setPointsToday(user.getPointsToday() + 1);
+        user.setIconPointsToday(user.getIconPointsToday() + 1);
         user.persistOrUpdate();
         if (LOGGER.isLoggable(java.util.logging.Level.INFO)) {
-            LOGGER.info(String.format("[PointService] Updated points: %d, pointsToday: %d for user: %s",
-                    user.getPoints(), user.getPointsToday(), publicKey));
+            LOGGER.info(String.format(
+                    "[PointService] Updated points: %d, pointsToday: %d, iconPointsToday: %d for user: %s",
+                    user.getPoints(), user.getPointsToday(), user.getIconPointsToday(), publicKey));
         }
         return user;
     }

--- a/backend/src/main/java/com/primos/service/PointsResetJob.java
+++ b/backend/src/main/java/com/primos/service/PointsResetJob.java
@@ -21,6 +21,8 @@ public class PointsResetJob {
         for (User user : users) {
             if (!today.equals(user.getPointsDate())) {
                 user.setPointsToday(0);
+                user.setIconPointsToday(0);
+                user.setHolderPointsToday(0);
                 user.setPointsDate(today);
                 user.persistOrUpdate();
             }


### PR DESCRIPTION
## Summary
- add per-source point tracking and daily limits
- reset all daily point tallies on login
- award holder points without exceeding daily cap

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Failed to read artifact descriptor for io.quarkus:quarkus-maven-plugin:jar:3.23.2)*

------
https://chatgpt.com/codex/tasks/task_e_68920a27b6b4832a8d49f9a8ac56139c