### PR TITLE
feat: add primos ranking and lab status icons

### DIFF
--- a/frontend/src/pages/PrimoLabs.tsx
+++ b/frontend/src/pages/PrimoLabs.tsx
@@ -9,6 +9,8 @@ import LinearProgress from '@mui/material/LinearProgress';
 import ThreeDRotationIcon from '@mui/icons-material/ThreeDRotation';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import MilitaryTechIcon from '@mui/icons-material/MilitaryTech';
+import BuildIcon from '@mui/icons-material/Build';
+import HomeIcon from '@mui/icons-material/Home';
 import Tooltip from '@mui/material/Tooltip';
 import { Link } from 'react-router-dom';
 import { getNFTByTokenAddress, fetchCollectionNFTsForOwner } from '../utils/helius';
@@ -78,22 +80,26 @@ const PrimoLabs: React.FC<{ connected?: boolean }> = ({ connected }) => {
       <Box className="labs-grid">
         <Tooltip title={t('experiment1_desc')} arrow>
           <Card className="lab-card" component={Link} to="/experiment1" sx={{ textDecoration: 'none' }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Box sx={{ position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
               <ThreeDRotationIcon sx={{ fontSize: 40 }} />
+              <BuildIcon sx={{ position: 'absolute', bottom: 0, right: 0, fontSize: 20 }} />
             </Box>
           </Card>
         </Tooltip>
         <Tooltip title={t('experiment2_desc')} arrow>
           <Card className="lab-card" component={Link} to="/stickers" sx={{ textDecoration: 'none' }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Box sx={{ position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
               <LocalOfferIcon sx={{ fontSize: 40 }} />
+              <BuildIcon sx={{ position: 'absolute', bottom: 0, right: 0, fontSize: 20 }} />
             </Box>
           </Card>
         </Tooltip>
         <Tooltip title={t('experiment3_desc')} arrow>
           <Card className="lab-card" component={Link} to="/trenches" sx={{ textDecoration: 'none' }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Box sx={{ position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
               <MilitaryTechIcon sx={{ fontSize: 40 }} />
+              <BuildIcon sx={{ position: 'absolute', bottom: 0, left: 0, fontSize: 20 }} />
+              <HomeIcon sx={{ position: 'absolute', bottom: 0, right: 0, fontSize: 20 }} />
             </Box>
           </Card>
         </Tooltip>

--- a/frontend/src/pages/Primos.css
+++ b/frontend/src/pages/Primos.css
@@ -26,6 +26,11 @@
   max-width: 100%;
 }
 
+.primos-rank {
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
 .primos-pills {
   display: flex;
   gap: 0.4rem;

--- a/frontend/src/pages/Primos.tsx
+++ b/frontend/src/pages/Primos.tsx
@@ -20,6 +20,7 @@ interface Member {
   domain?: string;
   points: number;
   pesos: number;
+  rank: number;
 }
 
 const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
@@ -34,9 +35,11 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
       setLoadingMembers(true);
       try {
         const res = await api.get<Member[]>('/api/user/primos');
-        const sorted = res.data.slice().sort((a: Member, b: Member) => b.pesos - a.pesos);
+        const sorted = res.data
+          .slice()
+          .sort((a: Member, b: Member) => b.pesos + b.points - (a.pesos + a.points));
         const enriched = await Promise.all(
-          sorted.map(async (m) => {
+          sorted.map(async (m, index) => {
             let image = '';
             if (m.pfp) {
               const nft = await getNFTByTokenAddress(m.pfp.replace(/"/g, ''));
@@ -47,7 +50,7 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
             }
             // fetch on-chain primary domain for each member
             const primary = await getPrimaryDomainName(m.publicKey);
-            return { ...m, pfp: image, domain: primary || m.domain };
+            return { ...m, pfp: image, domain: primary || m.domain, rank: index + 1 };
           })
         );
         setMembers(enriched);
@@ -89,6 +92,7 @@ const Primos: React.FC<{ connected?: boolean }> = ({ connected }) => {
                 style={{ textDecoration: 'none', color: 'inherit' }}
               >
                 <Box className="primos-card">
+                  <Typography className="primos-rank">#{m.rank}</Typography>
                   <Avatar
                     src={m.pfp || undefined}
                     sx={{ width: 56, height: 56 }}


### PR DESCRIPTION
## Summary
- rank primos by combined pesos and points
- show ranking number and order descending
- mark lab experiments with build/home icons for feature status

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: 26 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689227767a70832ab1c7e0c3c066ea8c