### PR TITLE
fix: include networkErrors in global admin debug

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -315,7 +315,8 @@ const GlobalAdminConsole = () => {
         contractsLoaded: 0,
         usersLoaded: 0,
         renderAttempted: true,
-        lastError: null
+        lastError: null,
+        networkErrors: []
       }}
       componentName={`Global - ${location?.pathname || 'Unknown'}`}
       additionalData={{


### PR DESCRIPTION
## Summary
- ensure GlobalAdminConsole passes required networkErrors array to `AdminDeveloperConsole`

## Testing
- `npm test -- --watchAll=false` *(fails: 25 failed, 14 passed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892be870ebc832abc76647bab59ee78