### PR TITLE
Fix caller NFT images loading like navbar PFP

### DIFF
--- a/frontend/src/components/__tests__/ContractPanelLatestCallers.test.tsx
+++ b/frontend/src/components/__tests__/ContractPanelLatestCallers.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ContractPanel from '../ContractPanel';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../i18n';
+import { fetchTrenchData } from '../../services/trench';
+import { getNFTByTokenAddress } from '../../utils/helius';
+
+jest.mock('../../services/token', () => ({
+  fetchTokenMetadata: jest.fn().mockResolvedValue(null),
+  fetchTokenInfo: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../../services/coingecko', () => ({
+  fetchCoinGeckoData: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../services/trench', () => ({
+  fetchTrenchData: jest.fn(),
+}));
+
+jest.mock('../../utils/helius', () => ({
+  getNFTByTokenAddress: jest.fn(),
+  fetchCollectionNFTsForOwner: jest.fn().mockResolvedValue([]),
+}));
+
+describe('ContractPanel latest callers', () => {
+  test('loads caller images via getNFTByTokenAddress', async () => {
+    (fetchTrenchData as jest.Mock).mockResolvedValue({
+      contracts: [{ contract: 'abc' }],
+      users: [],
+      latestCallers: {
+        abc: [
+          { caller: 'c1', pfp: 'token1' },
+          { caller: 'c2', pfp: 'token2' },
+        ],
+      },
+    });
+    (getNFTByTokenAddress as jest.Mock)
+      .mockResolvedValueOnce({ image: 'img1' })
+      .mockResolvedValueOnce({ image: 'img2' });
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <ContractPanel contract="abc" open={true} onClose={() => {}} />
+      </I18nextProvider>
+    );
+
+    await waitFor(() => {
+      expect(getNFTByTokenAddress).toHaveBeenCalledTimes(2);
+    });
+
+    const avatars = screen.getAllByAltText('Caller profile picture');
+    expect(avatars[0]).toHaveAttribute('src', 'img1');
+    expect(avatars[1]).toHaveAttribute('src', 'img2');
+  });
+});

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -51,6 +51,7 @@
   "select_nft_as_pfp": "Select NFT as PFP",
   "hide_nft_selection": "Hide NFT Selection",
   "profile_nft_alt": "Profile NFT",
+  "caller_pfp_alt": "Caller profile picture",
   "whale": "Whale",
   "fish": "Fish",
   "shrimp": "Shrimp",

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -51,6 +51,7 @@
   "select_nft_as_pfp": "Seleccionar NFT como PFP",
   "hide_nft_selection": "Ocultar selección de NFT",
   "profile_nft_alt": "NFT de perfil",
+  "caller_pfp_alt": "Foto de perfil del llamador",
   "whale": "Ballena",
   "fish": "Pez",
   "shrimp": "Camarón",

--- a/frontend/src/services/__tests__/trench.test.ts
+++ b/frontend/src/services/__tests__/trench.test.ts
@@ -24,6 +24,11 @@ describe('trench service', () => {
           { publicKey: 'u1', pfp: 'p1', count: 1, contracts: [] },
           { publicKey: 'u2', pfp: '', count: 1, contracts: [] },
         ],
+        latestCallers: {
+          c1: [
+            { caller: 'lc1', pfp: 'lp1' },
+          ],
+        },
       },
     });
     (helius.getNFTsByTokenAddresses as jest.Mock).mockResolvedValue({
@@ -37,6 +42,7 @@ describe('trench service', () => {
     expect(data.contracts[0].image).toBe('cimg');
     expect(data.users[0].pfp).toBe('pimg');
     expect(data.users[1].pfp).toBe('u2img');
+    expect(data.latestCallers.c1[0].pfp).toBe('lp1');
     expect(helius.getNFTsByTokenAddresses).toHaveBeenCalledWith(['c1', 'p1']);
     expect(api.get).toHaveBeenCalledWith('/api/trench');
   });

--- a/frontend/src/services/trench.ts
+++ b/frontend/src/services/trench.ts
@@ -73,16 +73,9 @@ export const fetchTrenchData = async (): Promise<TrenchData> => {
     .map((u) => u.pfp?.replace(/"/g, ''))
     .filter((a): a is string => !!a);
 
-  // Get all caller PFP addresses from latest callers
-  const latestCallerPfpAddresses = Object.values(latestCallersRaw)
-    .flat()
-    .map((caller) => caller.pfp?.replace(/"/g, ''))
-    .filter((a): a is string => !!a);
-
   const nftMap = await getNFTsByTokenAddresses([
     ...contractAddresses,
     ...userPfpAddresses,
-    ...latestCallerPfpAddresses,
   ]);
 
   const contracts = contractsArr.map((c) => ({
@@ -107,26 +100,8 @@ export const fetchTrenchData = async (): Promise<TrenchData> => {
     })
   );
 
-  // Process latest callers data
-  const latestCallers: Record<string, TrenchCallerInfo[]> = {};
-  for (const [contract, callers] of Object.entries(latestCallersRaw)) {
-    latestCallers[contract] = await Promise.all(
-      callers.map(async (caller) => {
-        const pfpAddr = caller.pfp?.replace(/"/g, '');
-        let image = '';
-        if (pfpAddr && nftMap[pfpAddr]) {
-          image = nftMap[pfpAddr].image;
-        } else {
-          const nfts = await fetchCollectionNFTsForOwner(
-            caller.caller,
-            PRIMO_COLLECTION
-          );
-          image = nfts[0]?.image || '';
-        }
-        return { ...caller, pfp: image } as TrenchCallerInfo;
-      })
-    );
-  }
+  // Return latest callers without fetching images; images are loaded client-side
+  const latestCallers: Record<string, TrenchCallerInfo[]> = latestCallersRaw as Record<string, TrenchCallerInfo[]>;
 
   return { contracts, users, latestCallers };
 };


### PR DESCRIPTION
## Summary
- load latest caller NFT images with per-token lookups like navbar PFP
- expose caller avatar alt text and add translations
- cover trench service latest callers with unit test

## Testing
- `CI=true npm test -- src/services/__tests__/trench.test.ts`
- `CI=true npm test` *(fails: coingecko service timeout, many other suites)*

------
https://chatgpt.com/codex/tasks/task_e_6892c54de0d0832ab124d1e32f09887f