### PR TITLE
Improve mobile responsiveness of contract panel

### DIFF
--- a/frontend/src/components/ContractPanel.css
+++ b/frontend/src/components/ContractPanel.css
@@ -197,6 +197,20 @@
     max-width: calc(100vw - 2rem);
     overflow-y: auto;
   }
+
+  .contract-panels {
+    flex-direction: column;
+  }
+
+  .token-info {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .token-image {
+    margin-bottom: 0.5rem;
+  }
 }
 
 @media (max-width: 500px) {

--- a/frontend/src/components/ContractPanel.tsx
+++ b/frontend/src/components/ContractPanel.tsx
@@ -883,13 +883,22 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose, 
                             >
                               <ListItemText
                                 primary={
-                                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                  <Box
+                                    className="token-holder-row"
+                                    sx={{
+                                      display: 'flex',
+                                      justifyContent: 'space-between',
+                                      alignItems: { xs: 'flex-start', sm: 'center' },
+                                      flexDirection: { xs: 'column', sm: 'row' },
+                                      gap: { xs: 0.5, sm: 0 }
+                                    }}
+                                  >
                                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                                       <Typography variant="body2" sx={{ fontWeight: 'bold', minWidth: '20px' }}>
                                         #{index + 1}
                                       </Typography>
-                                      <Typography 
-                                        variant="body2" 
+                                      <Typography
+                                        variant="body2"
                                         sx={{ 
                                           fontFamily: 'monospace', 
                                           cursor: 'pointer',
@@ -901,7 +910,16 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose, 
                                         {formatAddress(holder.address)}
                                       </Typography>
                                     </Box>
-                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box
+                                      className="holder-metrics"
+                                      sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: 1,
+                                        mt: { xs: 0.5, sm: 0 },
+                                        alignSelf: { xs: 'stretch', sm: 'auto' }
+                                      }}
+                                    >
                                       <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
                                         {holder.percentage.toFixed(2)}%
                                       </Typography>


### PR DESCRIPTION
## Summary
- make contract panel sections stack vertically on small screens
- adjust token info and holders list to display cleanly below 700px

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in axios)*

------
https://chatgpt.com/codex/tasks/task_e_689399847d08832a9bb558f4b935322a