### PR TITLE
Reset daily points when user becomes Primo

### DIFF
--- a/backend/src/main/java/com/primos/service/LoginService.java
+++ b/backend/src/main/java/com/primos/service/LoginService.java
@@ -72,10 +72,21 @@ public class LoginService {
         }
         user.persistOrUpdate();
 
+        boolean wasHolder = user.isPrimoHolder();
+
         // Update NFT count from the blockchain on each login
         int count = heliusService.getPrimoCount(user.getPublicKey());
         user.setNftCount(count);
-        updateHolderStatus(user, count > 0);
+        boolean isHolder = count > 0;
+        updateHolderStatus(user, isHolder);
+
+        if (isHolder && !wasHolder) {
+            user.setPointsToday(0);
+            user.setIconPointsToday(0);
+            user.setHolderPointsToday(0);
+            user.setPointsDate(LocalDate.now().toString());
+            user.persistOrUpdate();
+        }
 
         // Trigger holder points job on login - it will only execute once per day
         holderPointsJob.awardHolderPointsToAllUsers();


### PR DESCRIPTION
## Summary
- Reset daily points and date when a user logs in as a Primo holder for the first time

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `npm test -- --watchAll=false` *(fails: Test Suites: 24 failed, 13 passed, 37 total)*

------
https://chatgpt.com/codex/tasks/task_e_6899f5af003c832ab167e765039be0b8