### PR TITLE
Fix HeliusService lambda capture compile error

### DIFF
--- a/backend/src/main/java/com/primos/service/HeliusService.java
+++ b/backend/src/main/java/com/primos/service/HeliusService.java
@@ -79,8 +79,9 @@ public class HeliusService {
                     page++;
                 }
             }
-            LOG.info(() -> "Helius returned count: " + total);
-            return total;
+            final int count = total;
+            LOG.info(() -> "Helius returned count: " + count);
+            return count;
         } catch (Exception e) {
             LOG.warning("Failed to fetch Primo count for wallet " + wallet + ": " + e.getMessage());
             return 0;


### PR DESCRIPTION
## Summary
- ensure HeliusService lambda references a final count variable to compile

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus:quarkus-bom:pom:3.23.2 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_689a1d03ca88832abbf90d9e2226a80d