### PR TITLE
feat: add merchandise page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import TrenchesFallback from './components/TrenchesFallback';
 import Docs from './pages/Docs';
 import Admin from './pages/Admin';
 import Work from './pages/Work';
+import Merch from './pages/Merch';
 import BetaRedeem from './components/BetaRedeem';
 import LoadingOverlay from './components/LoadingOverlay';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -255,6 +256,7 @@ const AppRoutes = () => {
           <Route path="/" element={<Home />} />
           <Route path="/market" element={<PrimosMarketGallery />} />
           <Route path="/docs" element={<Docs />} />
+          <Route path="/merch" element={<Merch />} />
 
           {publicKey && (isHolder || betaRedeemed) && userExists && (
             <>

--- a/frontend/src/components/SidebarNav.tsx
+++ b/frontend/src/components/SidebarNav.tsx
@@ -16,6 +16,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import PeopleIcon from '@mui/icons-material/People';
 import MilitaryTechIcon from '@mui/icons-material/MilitaryTech';
 import WorkIcon from '@mui/icons-material/Work';
+import LocalMallIcon from '@mui/icons-material/LocalMall';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 
@@ -32,6 +33,7 @@ const SidebarNav: React.FC = () => {
     { to: '/', icon: <HomeIcon />, label: t('home'), show: true, end: true },
     { to: '/market', icon: <StorefrontIcon />, label: t('market_title'), show: true },
     { to: '/docs', icon: <MenuBookIcon />, label: t('docs_title'), show: true },
+    { to: '/merch', icon: <LocalMallIcon />, label: t('merch_title'), show: true },
     { to: '/trenches', icon: <MilitaryTechIcon />, label: t('experiment3_title'), show: true },
     {
       to: '/collected',

--- a/frontend/src/locales/en/en.json
+++ b/frontend/src/locales/en/en.json
@@ -81,6 +81,7 @@
   "primo_labs_login_prompt": "Please login to access Primo Labs",
   "primo_labs_desc": "Primo Labs will function as a launchpad and innovation hub for new features, NFT utilities, and community experiments. Stay tuned for exclusive tools and early access to upcoming projects.",
   "docs_title": "Docs",
+  "merch_title": "Merch",
   "docs_welcome": "In the sprawling landscape of guides and references that could easily lead you astray for ages, you will eventually discover by the final words that this is the official Primos Marketplace documentation.",
   "docs_treasury_title": "Decentralized Community Treasury",
   "docs_treasury_desc": "A permissioned Solana marketplace integrated with the Magic Eden API: a 2% market taker fee plus a 5% creator royalty, and additional on-chain community (2.4%) and operations (1.4%) fees. All proceeds fuel a shared on-chain treasury—powering buybacks, boosting floor price, and building real community ownership through DeFi mechanics.",

--- a/frontend/src/locales/es/es.json
+++ b/frontend/src/locales/es/es.json
@@ -81,6 +81,7 @@
   "primo_labs_login_prompt": "Por favor inicia sesión para acceder a Primo Labs",
   "primo_labs_desc": "Primo Labs funcionará como una plataforma de lanzamiento y centro de innovación para nuevas funciones, utilidades NFT y experimentos comunitarios. Próximamente: herramientas exclusivas y acceso anticipado a nuevos proyectos.",
   "docs_title": "Docs",
+  "merch_title": "Mercancía",
   "docs_welcome": "En el extenso panorama de guías, referencias y tutoriales interminables que pueden rodear cualquier proyecto, finalmente has llegado al lugar donde, después de mucho leer y desplazarte, descubrirás que esta es la documentación oficial de Primos Marketplace.",
   "docs_treasury_title": "Tesorería Comunitaria Descentralizada",
   "docs_treasury_desc": "Un marketplace en Solana integrado con la API de Magic Eden: comisión de comprador (2%) más royalty de creador (5%) y tarifas on-chain adicionales de comunidad (2.4%) y operaciones (1.4%). Todos los ingresos alimentan una tesorería compartida on-chain: impulsan recompras, elevan el precio floor y construyen verdadera propiedad comunitaria mediante mecánicas DeFi.",

--- a/frontend/src/pages/Merch.tsx
+++ b/frontend/src/pages/Merch.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Card, CardMedia, CardActions, Button, Typography, Box } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import './PrimosMarketGallery.css';
+
+const merchItems = [
+  { id: 1, name: 'Primos T-Shirt', image: 'https://placehold.co/400x400?text=T-Shirt', price: '$25' },
+  { id: 2, name: 'Primos Cap', image: 'https://placehold.co/400x400?text=Cap', price: '$20' },
+  { id: 3, name: 'Primos Mug', image: 'https://placehold.co/400x400?text=Mug', price: '$15' },
+  { id: 4, name: 'Primos Sticker', image: 'https://placehold.co/400x400?text=Sticker', price: '$5' },
+];
+
+const Merch: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Box className="market-gallery">
+      <Box className="market-header-row">
+        <Typography className="market-title">{t('merch_title')}</Typography>
+      </Box>
+      <Box className="market-nft-list nft-list">
+        {merchItems.map((item) => (
+          <Card key={item.id} className="market-card">
+            <CardMedia
+              component="img"
+              image={item.image}
+              alt={item.name}
+              className="market-nft-img"
+            />
+            <CardActions className="market-card-footer">
+              <Typography className="market-nft-name">{item.name}</Typography>
+              <Typography className="market-nft-price">{item.price}</Typography>
+              <Button variant="contained" color="primary">
+                {t('buy_now')}
+              </Button>
+            </CardActions>
+          </Card>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default Merch;

--- a/frontend/src/pages/__tests__/Merch.test.tsx
+++ b/frontend/src/pages/__tests__/Merch.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../i18n';
+import Merch from '../Merch';
+
+describe('Merch', () => {
+  test('renders merch items', () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <Merch />
+      </I18nextProvider>
+    );
+    expect(screen.getByText(/Merch/i)).toBeTruthy();
+    expect(screen.getAllByText('Buy Now').length).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- add merchandise page with placeholder items
- wire up merch route and sidebar navigation icon
- localize merch strings and add basic unit test

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f8cbea984832aaf9192a68b6b3cf7