### PR TITLE
Prefer versioned buy transactions

### DIFF
--- a/frontend/src/utils/transaction.ts
+++ b/frontend/src/utils/transaction.ts
@@ -177,7 +177,8 @@ export const executeBuyNow = async (
     params.sellerExpiry = listing.sellerExpiry.toString();
 
   const resp = await getBuyNowInstructions(params);
-  const data = resp.txSigned?.data;
+  // prefer the versioned transaction if provided to avoid size limits
+  const data = resp.v0?.txSigned?.data ?? resp.txSigned?.data;
   if (!data) throw new Error('Invalid response');
 
   const txBuy = decodeTransaction(data);


### PR DESCRIPTION
## Summary
- handle Magic Eden buy instructions using versioned transaction data to avoid packet size errors
- adjust transaction tests for versioned data and valid mock transactions

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a7d8aa678c832ab14f6babe59fa3ad