### PR TITLE
feat: award daily holder points without login

### DIFF
--- a/backend/src/main/java/com/primos/service/HolderPointsJob.java
+++ b/backend/src/main/java/com/primos/service/HolderPointsJob.java
@@ -2,6 +2,7 @@ package com.primos.service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import com.primos.model.User;
@@ -21,13 +22,26 @@ public class HolderPointsJob {
         this.heliusService = heliusService;
     }
 
-    @Scheduled(cron = "0 0 10 * * ?")
+    @Scheduled(cron = "0 0 20 * * ?", timeZone = "America/New_York")
     void awardHolderPoints() {
         awardHolderPointsToAllUsers();
     }
 
     public void awardHolderPointsToAllUsers() {
         String today = LocalDate.now().toString();
+        Map<String, Integer> holderMap = heliusService.getPrimoHolders();
+
+        // Ensure all holders exist in the database
+        holderMap.keySet().forEach(address -> {
+            if (User.find("publicKey", address).firstResult() == null) {
+                User newUser = new User();
+                newUser.setPublicKey(address);
+                newUser.setPrimoHolder(true);
+                newUser.setDaoMember(true);
+                newUser.persist();
+            }
+        });
+
         List<User> users = User.listAll();
 
         // Check if holder points have already been awarded today
@@ -45,28 +59,26 @@ public class HolderPointsJob {
 
         for (User user : users) {
             try {
-                int count = heliusService.getPrimoCount(user.getPublicKey());
+                int count = holderMap.getOrDefault(user.getPublicKey(), 0);
+                boolean isHolder = count > 0;
                 user.setNftCount(count);
-                user.setPrimoHolder(count > 0);
-                user.setDaoMember(count > 0);
+                user.setPrimoHolder(isHolder);
+                user.setDaoMember(isHolder);
 
-                // Reset daily points if it's a new day
-                if (!today.equals(user.getPointsDate())) {
-                    user.setPointsDate(today);
-                    user.setPointsToday(0);
-                    user.setIconPointsToday(0);
-                    user.setHolderPointsToday(0);
-                }
+                // Reset daily points counts for new day
+                user.setPointsDate(today);
+                user.setPointsToday(0);
+                user.setIconPointsToday(0);
+                user.setHolderPointsToday(0);
 
-                if (count > 0) { // Only award points to holders
+                if (isHolder) {
                     int multiplier = 1 + count / 5;
                     int add = 18 * multiplier;
-                    int remaining = PointService.MAX_POINTS_PER_DAY - user.getPointsToday();
-                    int toAdd = Math.clamp(add, 0, remaining);
+                    int toAdd = Math.clamp(add, 0, PointService.MAX_POINTS_PER_DAY);
 
                     user.setPoints(user.getPoints() + toAdd);
-                    user.setPointsToday(user.getPointsToday() + toAdd);
-                    user.setHolderPointsToday(user.getHolderPointsToday() + toAdd);
+                    user.setPointsToday(toAdd);
+                    user.setHolderPointsToday(toAdd);
 
                     if (LOG.isLoggable(java.util.logging.Level.INFO)) {
                         LOG.info(String.format("Awarded %d holder points to user %s (NFT count: %d)",

--- a/backend/src/test/java/com/primos/service/HolderPointsJobTest.java
+++ b/backend/src/test/java/com/primos/service/HolderPointsJobTest.java
@@ -2,6 +2,9 @@ package com.primos.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import com.primos.model.User;
@@ -11,13 +14,20 @@ public class HolderPointsJobTest {
     public void testAwardHolderPoints() {
         User user = new User();
         user.setPublicKey("holder");
-        user.setNftCount(7); // multiplier 2
         user.setPoints(10);
         user.persist();
 
-        HeliusService heliusService = new HeliusService(); // or mock as needed
+        HeliusService heliusService = new HeliusService() {
+            @Override
+            public Map<String, Integer> getPrimoHolders() {
+                Map<String, Integer> map = new HashMap<>();
+                map.put("holder", 7); // multiplier 2
+                return map;
+            }
+        };
+
         HolderPointsJob job = new HolderPointsJob(heliusService);
-        job.awardHolderPoints();
+        job.awardHolderPointsToAllUsers();
 
         User updated = User.find("publicKey", "holder").firstResult();
         assertNotNull(updated);


### PR DESCRIPTION
## Summary
- fetch Primos collection holders from Magic Eden and ensure DB users exist
- schedule holder point awards nightly at 8PM EST with daily counter reset
- remove login-triggered point resets

## Testing
- `mvn -q test` *(fails: Unresolveable build extension due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acf3b7e3b4832aac02471894dfc501