### PR TITLE
Fix DAO members retrieval for Primos page

### DIFF
--- a/backend/src/main/java/com/primos/service/UserService.java
+++ b/backend/src/main/java/com/primos/service/UserService.java
@@ -25,7 +25,16 @@ public class UserService {
 
     public List<User> getDaoMembers(String walletKey) {
         LOG.info("Retrieving DAO members");
-        List<User> users = User.list("primoHolder", true);
+        // "Primos" page should list every DAO member stored in the database.
+        //
+        // The previous implementation queried users by the `primoHolder` flag,
+        // which reflects whether the user currently holds a Primo NFT on-chain.
+        // This field may be `false` even for members who have previously joined
+        // the DAO (for example after selling their NFT) which caused the API to
+        // return an empty list for valid members.  The frontend relies on this
+        // endpoint to populate the Primos page, so we instead filter by the
+        // `daoMember` field that represents membership status.
+        List<User> users = User.list("daoMember", true);
         LOG.info(() -> "DAO members found: " + users.size());
         return users;
     }


### PR DESCRIPTION
## Summary
- pull members for Primos page based on `daoMember` flag rather than `primoHolder`

## Testing
- `npm test --silent -- --watchAll=false`
- `mvn -q test` *(fails: Unresolveable build extension: Plugin io.quarkus:quarkus-maven-plugin:3.23.2 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68acff96dce0832a83332bff965d8358