### PR TITLE
Ensure Primos and Trenches data pulled from DB

### DIFF
--- a/frontend/src/pages/Trenches.tsx
+++ b/frontend/src/pages/Trenches.tsx
@@ -275,7 +275,10 @@ const Trenches: React.FC = () => {
   const loadPrimoTokens = async () => {
     setLoadingPrimoTokens(true);
     try {
-      const res = await api.get<{ publicKey: string }[]>('/api/user/primos');
+      const headers = wallet.publicKey
+        ? { headers: { 'X-Public-Key': wallet.publicKey.toBase58() } }
+        : undefined;
+      const res = await api.get<{ publicKey: string }[]>('/api/user/primos', headers);
       const members = Array.isArray(res.data) ? res.data : [];
       const tokenMap = new Map<string, HeliusFungibleToken>();
       await Promise.all(

--- a/frontend/src/pages/__tests__/Primos.test.tsx
+++ b/frontend/src/pages/__tests__/Primos.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Primos from '../Primos';
 
+jest.mock('@solana/wallet-adapter-react', () => ({
+  useWallet: () => ({ publicKey: null }),
+}));
+
 jest.mock('../../utils/api', () => ({
   get: jest.fn(() =>
     Promise.resolve({


### PR DESCRIPTION
## Summary
- Fetch DAO members on Primos page with X-Public-Key so list comes from the database
- Request Primos list with wallet header when loading Primo tokens on Trenches page
- Adjust tests to mock wallet adapter

## Testing
- `npx jest src/pages/__tests__/Primos.test.tsx src/pages/__tests__/Trenches.test.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0acd5e10832a82b0c0140f7543cc