### PR TITLE
Expose Primo holders endpoint and clean up user retrieval

### DIFF
--- a/backend/src/main/java/com/primos/resource/UserResource.java
+++ b/backend/src/main/java/com/primos/resource/UserResource.java
@@ -42,9 +42,8 @@ public class UserResource {
 
     @GET
     @Path("/{publicKey}")
-    public User getUser(@PathParam("publicKey") String publicKey,
-            @HeaderParam("X-Public-Key") String walletKey) {
-        return userService.getUser(publicKey, walletKey);
+    public User getUser(@PathParam("publicKey") String publicKey) {
+        return userService.getUser(publicKey);
     }
 
     @PUT
@@ -74,8 +73,14 @@ public class UserResource {
 
     @GET
     @Path("/primos")
-    public java.util.List<User> getDaoMembers(@HeaderParam("X-Public-Key") String walletKey) {
-        return userService.getDaoMembers(walletKey);
+    public java.util.List<User> getDaoMembers() {
+        return userService.getDaoMembers();
+    }
+
+    @GET
+    @Path("/holders")
+    public java.util.List<User> getPrimoHolders() {
+        return userService.getPrimoHolders();
     }
 
     @GET

--- a/backend/src/main/java/com/primos/service/UserService.java
+++ b/backend/src/main/java/com/primos/service/UserService.java
@@ -13,7 +13,7 @@ public class UserService {
 
     private static final Logger LOG = Logger.getLogger(UserService.class.getName());
 
-    public User getUser(String publicKey, String walletKey) {
+    public User getUser(String publicKey) {
         LOG.info(() -> "Fetching user with public key: " + publicKey);
         User user = User.find("publicKey", publicKey).firstResult();
         if (user == null) {
@@ -23,7 +23,12 @@ public class UserService {
         return user;
     }
 
-    public List<User> getDaoMembers(String walletKey) {
+    /**
+     * Retrieves all users who have joined the DAO. Membership is tracked in the
+     * database via the {@code daoMember} flag, which is updated whenever a user
+     * logs in or when scheduled jobs reconcile on‑chain holdings.
+     */
+    public List<User> getDaoMembers() {
         LOG.info("Retrieving DAO members");
         // "Primos" page should list every DAO member stored in the database.
         //
@@ -37,6 +42,17 @@ public class UserService {
         List<User> users = User.list("daoMember", true);
         LOG.info(() -> "DAO members found: " + users.size());
         return users;
+    }
+
+    /**
+     * Fetches users who currently hold at least one Primo NFT. The
+     * {@code primoHolder} flag is maintained by login flows and background jobs
+     * that synchronize on‑chain data with the database, so this query simply
+     * reflects the latest state stored in MongoDB.
+     */
+    public List<User> getPrimoHolders() {
+        LOG.info("Retrieving Primo holders");
+        return User.list("primoHolder", true);
     }
 
     public User getByDomain(String domain) {

--- a/backend/src/test/java/com/primos/resource/UserResourceTest.java
+++ b/backend/src/test/java/com/primos/resource/UserResourceTest.java
@@ -48,7 +48,7 @@ public class UserResourceTest {
     }
 
     @Test
-    public void testGetUserWithoutHeader() {
+    public void testGetUser() {
         UserResource resource = new UserResource();
         LoginRequest req = new LoginRequest();
         req.publicKey = "dummy1";
@@ -57,21 +57,7 @@ public class UserResourceTest {
         code.persist();
         req.betaCode = "B2";
         resource.login(req);
-        com.primos.model.User user = resource.getUser("dummy1", null);
-        assertNotNull(user);
-    }
-
-    @Test
-    public void testGetUserWithHeader() {
-        UserResource resource = new UserResource();
-        LoginRequest req = new LoginRequest();
-        req.publicKey = "dummy2";
-        com.primos.model.BetaCode code = new com.primos.model.BetaCode();
-        code.setCode("B3");
-        code.persist();
-        req.betaCode = "B3";
-        resource.login(req);
-        com.primos.model.User user = resource.getUser("dummy2", "dummy2");
+        com.primos.model.User user = resource.getUser("dummy1");
         assertNotNull(user);
     }
 
@@ -86,23 +72,23 @@ public class UserResourceTest {
         code.persist();
         req.betaCode = "B4";
         resource.login(req);
-        java.util.List<com.primos.model.User> members = resource.getDaoMembers("member");
+        java.util.List<com.primos.model.User> members = resource.getDaoMembers();
         assertFalse(members.isEmpty());
     }
 
     @Test
-    public void testGetDaoMembersWithoutHeader() {
+    public void testGetPrimoHolders() {
         UserResource resource = new UserResource();
         LoginRequest req = new LoginRequest();
-        req.publicKey = "member2";
+        req.publicKey = "holder";
         req.primoHolder = true;
         com.primos.model.BetaCode code = new com.primos.model.BetaCode();
-        code.setCode("B4a");
+        code.setCode("B4b");
         code.persist();
-        req.betaCode = "B4a";
+        req.betaCode = "B4b";
         resource.login(req);
-        java.util.List<com.primos.model.User> members = resource.getDaoMembers(null);
-        assertFalse(members.isEmpty());
+        java.util.List<com.primos.model.User> holders = resource.getPrimoHolders();
+        assertFalse(holders.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- expose `/api/user/holders` to return Primo NFT holders using the existing database flag
- remove unused wallet header and simplify `getUser` and DAO members API
- add regression tests for holder and DAO member endpoints

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin io.quarkus:quarkus-maven-plugin:3.23.2 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0dd4d788832aac5dc090c3a9aecf