### PR TITLE
Add Primo token discovery endpoint and UI

### DIFF
--- a/backend/src/main/java/com/primos/model/PrimoToken.java
+++ b/backend/src/main/java/com/primos/model/PrimoToken.java
@@ -1,0 +1,36 @@
+package com.primos.model;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
+
+@MongoEntity(collection = "primoTokens")
+public class PrimoToken extends PanacheMongoEntity {
+    private String contract;
+    private int holderCount;
+    private long updatedAt;
+
+    public String getContract() {
+        return contract;
+    }
+
+    public void setContract(String contract) {
+        this.contract = contract;
+    }
+
+    public int getHolderCount() {
+        return holderCount;
+    }
+
+    public void setHolderCount(int holderCount) {
+        this.holderCount = holderCount;
+    }
+
+    public long getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(long updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}
+

--- a/backend/src/main/java/com/primos/resource/CoinGeckoProxyResource.java
+++ b/backend/src/main/java/com/primos/resource/CoinGeckoProxyResource.java
@@ -113,6 +113,53 @@ public class CoinGeckoProxyResource {
     }
 
     @GET
+    @Path("/coins/{network}/contract/{contractAddress}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getTokenByContract(
+            @PathParam("network") String network,
+            @PathParam("contractAddress") String contractAddress,
+            @QueryParam("x_cg_demo_api_key") String demoApiKey) {
+
+        try {
+            String url = COINGECKO_BASE_URL + "/coins/" + network + "/contract/" + contractAddress;
+            if (demoApiKey != null) {
+                url += "?x_cg_demo_api_key=" + demoApiKey;
+            }
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(30))
+                    .header("Accept", "application/json")
+                    .header("User-Agent", "PrimosMarketplace/1.0")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            return Response.status(response.statusCode())
+                    .entity(response.body())
+                    .header(CORS_ALLOW_ORIGIN, WILDCARD_ORIGIN)
+                    .header(CORS_ALLOW_METHODS, GET_METHOD)
+                    .header(CORS_ALLOW_HEADERS, CONTENT_TYPE)
+                    .build();
+
+        } catch (java.io.IOException e) {
+            System.err.println("Error proxying CoinGecko token request: " + e.getMessage());
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("{\"error\": \"Failed to fetch data from CoinGecko\"}")
+                    .header(CORS_ALLOW_ORIGIN, WILDCARD_ORIGIN)
+                    .build();
+        } catch (java.lang.InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.err.println("CoinGecko token request interrupted: " + e.getMessage());
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("{\"error\": \"Request interrupted\"}")
+                    .header(CORS_ALLOW_ORIGIN, WILDCARD_ORIGIN)
+                    .build();
+        }
+    }
+
+    @GET
     @Path("/pools/{tokenAddress}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getTokenPools(

--- a/backend/src/main/java/com/primos/resource/PrimoTokenResource.java
+++ b/backend/src/main/java/com/primos/resource/PrimoTokenResource.java
@@ -1,0 +1,25 @@
+package com.primos.resource;
+
+import java.util.List;
+
+import com.primos.model.PrimoToken;
+import com.primos.service.PrimoTokensService;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api/primo-tokens")
+@Produces(MediaType.APPLICATION_JSON)
+public class PrimoTokenResource {
+
+    @Inject
+    PrimoTokensService primoTokensService;
+
+    @GET
+    public List<PrimoToken> getTokens() {
+        return primoTokensService.updateAndGetPrimoTokens();
+    }
+}


### PR DESCRIPTION
## Summary
- pull Primo-held tokens from Helius token API and store in DB
- proxy CoinGecko contract endpoint and surface token images/market data
- show discovered Primo tokens on home page using CoinGecko metadata

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad31d53fac832a9f82b9bdcbf5e4e8