### PR TITLE
Add TradingView charts to ContractPanel

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,7 @@
         "react-router": "^6.22.3",
         "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
+        "react-ts-tradingview-widgets": "^1.2.8",
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
         "url": "^0.11.4",
@@ -20980,6 +20981,16 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-ts-tradingview-widgets": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-ts-tradingview-widgets/-/react-ts-tradingview-widgets-1.2.8.tgz",
+      "integrity": "sha512-ozJwn+0x+Kp2DcqoB9LTDWQHyv3JCdfShb8ooHo+ZB9xjKAXW0irD/gK1deWv4oaAnTxmzKLfmr1QNfAhv+MJw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.1.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.1.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,9 +25,9 @@
     "@radix-ui/react-tabs": "^1.0.6",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@solana/wallet-adapter-base": "^0.9.24",
+    "@solana/wallet-adapter-phantom": "^0.9.28",
     "@solana/wallet-adapter-react": "^0.15.37",
     "@solana/wallet-adapter-react-ui": "^0.9.38",
-    "@solana/wallet-adapter-phantom": "^0.9.28",
     "@solana/wallet-adapter-solflare": "^0.6.32",
     "@solana/web3.js": "^1.98.2",
     "assert": "^2.1.0",
@@ -44,11 +44,12 @@
     "querystring": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.12.0",
     "react-i18next": "^11.18.6",
+    "react-icons": "^4.12.0",
     "react-router": "^6.22.3",
     "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
+    "react-ts-tradingview-widgets": "^1.2.8",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "url": "^0.11.4",
@@ -82,7 +83,9 @@
     ]
   },
   "jest": {
-    "testMatch": ["<rootDir>/src/__tests__/**/*.test.(ts|tsx)"]
+    "testMatch": [
+      "<rootDir>/src/__tests__/**/*.test.(ts|tsx)"
+    ]
   },
   "overrides": {
     "sha.js": "2.4.12"

--- a/frontend/src/components/ContractPanel.tsx
+++ b/frontend/src/components/ContractPanel.tsx
@@ -42,6 +42,7 @@ import { getTokenLargestAccounts, TokenHolder } from '../services/helius';
 import { getLikes, toggleLike } from '../utils/likes';
 import { getTokenReactions, toggleTokenLike, toggleTokenDislike, TokenReactionData } from '../utils/tokenReactions';
 import AdminDeveloperConsole from './AdminDeveloperConsole';
+import SolanaChart from './SolanaChart';
 import './ContractPanel.css';
 
 interface ContractPanelProps {
@@ -58,6 +59,7 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose, 
 
   const [token, setToken] = useState<TokenMetadata | null>(null);
   const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null);
+  const [chartSymbol, setChartSymbol] = useState<string | null>(null);
   const [coinGeckoData, setCoinGeckoData] = useState<CoinGeckoEntry[]>([]);
   const [tokenHolders, setTokenHolders] = useState<TokenHolder[]>([]);
   const [holdersExpanded, setHoldersExpanded] = useState(false);
@@ -539,6 +541,21 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose, 
     loadData();
   }, [open, contract, t]);
 
+  useEffect(() => {
+    if (
+      tokenInfo?.tickerBase &&
+      tokenInfo?.tickerTarget &&
+      tokenInfo?.tickerMarketName
+    ) {
+      const market = tokenInfo.tickerMarketName.replace(/\s+/g, '').toUpperCase();
+      const base = tokenInfo.tickerBase.toUpperCase();
+      const target = tokenInfo.tickerTarget.toUpperCase();
+      setChartSymbol(`${market}:${base}${target}`);
+    } else {
+      setChartSymbol(null);
+    }
+  }, [tokenInfo]);
+
   // Separate useEffect for PFP loading with timeout to avoid race conditions
   useEffect(() => {
     if (!open || !contract) return;
@@ -973,11 +990,16 @@ const ContractPanel: React.FC<ContractPanelProps> = ({ contract, open, onClose, 
             )}
           </Box>
 
-          <Box className="market-data-panel">
-            <Typography className="dialog-title">{t('market_data')}</Typography>
-            <Box className="market-data-list" sx={{ mt: 1 }}>
-              {coinGeckoData.map((entry) => (
-                <Box key={entry.id} sx={{ mb: 1.5, display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1, backgroundColor: '#fafafa', borderRadius: 0.5 }}>
+            <Box className="market-data-panel">
+              <Typography className="dialog-title">{t('market_data')}</Typography>
+              {chartSymbol && (
+                <Box sx={{ height: 300, mt: 2 }}>
+                  <SolanaChart symbol={chartSymbol} />
+                </Box>
+              )}
+              <Box className="market-data-list" sx={{ mt: 1 }}>
+                {coinGeckoData.map((entry) => (
+                  <Box key={entry.id} sx={{ mb: 1.5, display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1, backgroundColor: '#fafafa', borderRadius: 0.5 }}>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     {geckoIcons[entry.id]}
                     <Typography variant="body2" component="div" sx={{ fontWeight: 'bold', color: '#333' }}>

--- a/frontend/src/components/SolanaChart.tsx
+++ b/frontend/src/components/SolanaChart.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { AdvancedRealTimeChart } from 'react-ts-tradingview-widgets';
+
+interface SolanaChartProps {
+  symbol: string;
+}
+
+const SolanaChart: React.FC<SolanaChartProps> = ({ symbol }) => {
+  return (
+    <div style={{ height: '100%', width: '100%' }}>
+      <AdvancedRealTimeChart
+        theme="dark"
+        symbol={symbol}
+        width="100%"
+        height="100%"
+        interval="1D"
+        timezone="Etc/UTC"
+        style="1"
+        locale="en"
+        withdateranges
+        allow_symbol_change={false}
+        hide_side_toolbar={false}
+      />
+    </div>
+  );
+};
+
+export default SolanaChart;

--- a/frontend/src/components/__tests__/ContractPanel.test.tsx
+++ b/frontend/src/components/__tests__/ContractPanel.test.tsx
@@ -21,6 +21,10 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => jest.fn(),
 }));
 
+jest.mock('react-ts-tradingview-widgets', () => ({
+  AdvancedRealTimeChart: () => <div data-testid="tradingview-chart" />
+}));
+
 import * as trenchService from '../../services/trench';
 
 const mockContractData = {


### PR DESCRIPTION
## Summary
- add SolanaChart component wrapping TradingView AdvancedRealTimeChart
- wire charts into ContractPanel, deriving widget symbol from token info
- expose charting library as dependency and mock in tests

## Testing
- `cd frontend && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ad3fb7bb94832ab1f659dc6b03dbed