### PR TITLE
feat: discover primo tokens via frontend

### DIFF
--- a/frontend/src/services/primoTokens.ts
+++ b/frontend/src/services/primoTokens.ts
@@ -1,0 +1,53 @@
+import api from '../utils/api';
+import { getTokensForOwner, HeliusFungibleToken } from './helius';
+
+export interface PrimoToken {
+  id?: string;
+  contract: string;
+  holderCount: number;
+  holders: string[];
+  holderDetails?: any[];
+  tradingViewCharts?: any[];
+  name?: string;
+  symbol?: string;
+  image?: string;
+  marketCap?: number;
+  priceChange24h?: number;
+}
+
+// Fetch tokens held by Primo holders directly from the blockchain.
+// Falls back to empty array if API key or holders are unavailable.
+export const fetchPrimoTokensOnChain = async (): Promise<PrimoToken[]> => {
+  try {
+    const res = await api.get('/api/user/holders');
+    const holders: { publicKey: string }[] = Array.isArray(res.data) ? res.data : [];
+
+    const tokenMap: Record<string, PrimoToken> = {};
+
+    for (const holder of holders) {
+      const tokens: HeliusFungibleToken[] = await getTokensForOwner(holder.publicKey);
+      tokens.forEach((token) => {
+        const id = token.id;
+        if (!id) return;
+        if (!tokenMap[id]) {
+          tokenMap[id] = {
+            id,
+            contract: id,
+            holderCount: 0,
+            holders: [],
+            name: token.name,
+            symbol: token.symbol,
+            image: token.image,
+          };
+        }
+        tokenMap[id].holderCount += 1;
+        tokenMap[id].holders.push(holder.publicKey);
+      });
+    }
+
+    return Object.values(tokenMap).sort((a, b) => b.holderCount - a.holderCount);
+  } catch (e) {
+    console.error('Failed to fetch Primo tokens on-chain:', e);
+    return [];
+  }
+};


### PR DESCRIPTION
## Summary
- add on-chain Primo token discovery utility
- fall back to frontend token fetch when backend API fails
- trigger on-chain token fetch from Trenches page

## Testing
- `CI=true npm test`
- `mvn -q test` *(fails: Non-resolvable dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ae71ed8218832a87b6e244562cfca0